### PR TITLE
Enable EM1 in idle hook

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <em_device.h>
 #include <em_gpio.h>
 #include <em_system.h>
+#include <em_emu.h>
 
 #include <FreeRTOS.h>
 #include <FreeRTOSConfig.h>
@@ -45,6 +46,7 @@ void vApplicationStackOverflowHook(xTaskHandle* pxTask, signed char* pcTaskName)
 
 void vApplicationIdleHook(void)
 {
+    EMU_EnterEM1();
 }
 
 static void BlinkLed0(void* param)


### PR DESCRIPTION
Enter Energy Mode 1 in FreeRTOS idle hook.

Average current during integration tests:
- Without Energy Mode: 5,24mA
- With EM1: 3,99mA

It's hard to get better comparision as it's not so easy to automate gathering measurments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/34)
<!-- Reviewable:end -->
