### PR TITLE
Much more strongly typed (and usable) file system interface.

### DIFF
--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -30,6 +30,8 @@ typedef enum {
     OSResultTimeout = 2,
     /** @brief Requested operation is invalid. */
     OSResultInvalidOperation = 3,
+    /** @brief Requested element was not found. */
+    OSResultNotFound = 4,
 } OSResult;
 
 /**

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -43,13 +43,13 @@ typedef enum {
     OSResultInterrupted = EINTR,
     /** I/O error */
     OSResultIOError = EIO,
-    /** Arg list too long */
+    /** Argument list too long */
     OSResultArgListTooLong = E2BIG,
     /** Bad file number */
     OSResultInvalidFileHandle = EBADF,
     /** No children */
     OSResultNoChildren = ECHILD,
-    /** Not enough space */
+    /** Not enough memory */
     OSResultNotEnoughMemory = ENOMEM,
     /** Permission denied */
     OSResultAccessDenied = EACCES,
@@ -89,7 +89,7 @@ typedef enum {
     OSResultDeadlock = EDEADLK,
     /** No lock */
     OSResultNoLock = ENOLCK,
-    /** No data (for no delay io) */
+    /** A non blocking operation could not be immediately completed */
     OSResultWouldBlock = ENODATA,
     /** Operation timed out. */
     OSResultTimeout = ETIME,
@@ -107,7 +107,7 @@ typedef enum {
     OSResultPathTooLong = ENAMETOOLONG,
     /** Too many symbolic links */
     OSResultLinkCycle = ELOOP,
-    /** Operation not supported on socket */
+    /** Operation not supported */
     OSResultNotSupported = EOPNOTSUPP,
     /** Protocol family not supported  */
     OSResultProtocolNotSupported = EPFNOSUPPORT,

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -1,6 +1,7 @@
 #ifndef LIBS_BASE_OS_H
 #define LIBS_BASE_OS_H
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -18,20 +19,111 @@ EXTERNC_BEGIN
  */
 #define MAX_DELAY 0xffffffffUL
 
+#ifndef ELAST
+// newlib workaround
+#if defined _NEWLIB_VERSION && defined __ELASTERROR
+#define ELAST __ELASTERROR
+#else
+#error "stdlib does not define ELAST errno value."
+#endif
+#endif
 /**
  * @brief Enumerator for all possible operating system error codes.
  */
 typedef enum {
-    /** @brief Success */
+    /** Success */
     OSResultSuccess = 0,
-    /** @brief Not enough resources to complete operation. */
-    OSResultOutOfResources = 1,
-    /** @brief Operation timed out. */
-    OSResultTimeout = 2,
+
     /** @brief Requested operation is invalid. */
-    OSResultInvalidOperation = 3,
-    /** @brief Requested element was not found. */
-    OSResultNotFound = 4,
+    OSResultInvalidOperation = ELAST,
+
+    /** Requested element was not found. */
+    OSResultNotFound = ENOENT,
+    /** Interrupted system call */
+    OSResultInterrupted = EINTR,
+    /** I/O error */
+    OSResultIOError = EIO,
+    /** Arg list too long */
+    OSResultArgListTooLong = E2BIG,
+    /** Bad file number */
+    OSResultInvalidFileHandle = EBADF,
+    /** No children */
+    OSResultNoChildren = ECHILD,
+    /** Not enough space */
+    OSResultNotEnoughMemory = ENOMEM,
+    /** Permission denied */
+    OSResultAccessDenied = EACCES,
+    /** Bad address */
+    OSResultInvalidAddress = EFAULT,
+    /** Device or resource busy */
+    OSResultBusy = EBUSY,
+    /** File exists */
+    OSResultFileExists = EEXIST,
+    /** Cross-device link */
+    OSResultInvalidLink = EXDEV,
+    /** No such device */
+    OSResultDeviceNotFound = ENODEV,
+    /** Not a directory */
+    OSResultNotADirectory = ENOTDIR,
+    /** Is a directory */
+    OSResultIsDirectory = EISDIR,
+    /** Invalid argument */
+    OSResultInvalidArgument = EINVAL,
+    /** Too many open files in system */
+    OSResultTooManyOpenFiles = ENFILE,
+    /** File descriptor value too large */
+    OSResultDescriptorTooLarge = EMFILE,
+    /** File too large */
+    OSResultFileTooLarge = EFBIG,
+    /** No space left on device */
+    OSResultOutOfDiskSpace = ENOSPC,
+    /** Illegal seek */
+    OSResultInvalidSeek = ESPIPE,
+    /** Read-only file system */
+    OSResultReadOnlyFs = EROFS,
+    /** Too many links */
+    OSResultTooManyLinks = EMLINK,
+    /** Result too large */
+    OSResultOutOfRange = ERANGE,
+    /** Deadlock */
+    OSResultDeadlock = EDEADLK,
+    /** No lock */
+    OSResultNoLock = ENOLCK,
+    /** No data (for no delay io) */
+    OSResultWouldBlock = ENODATA,
+    /** Operation timed out. */
+    OSResultTimeout = ETIME,
+    /** Protocol error */
+    OSResultProtocolError = EPROTO,
+    /** Bad message */
+    OSResultInvalidMessage = EBADMSG,
+    /** Inappropriate file type or format */
+    OSResultInvalidFileFormat = EFTYPE,
+    /** Function not implemented */
+    OSResultNotImplemented = ENOSYS,
+    /** Directory not empty */
+    OSResultDirectoryNotEmpty = ENOTEMPTY,
+    /** File or path name too long */
+    OSResultPathTooLong = ENAMETOOLONG,
+    /** Too many symbolic links */
+    OSResultLinkCycle = ELOOP,
+    /** Operation not supported on socket */
+    OSResultNotSupported = EOPNOTSUPP,
+    /** Protocol family not supported  */
+    OSResultProtocolNotSupported = EPFNOSUPPORT,
+    /** No buffer space available */
+    OSResultBufferNotAvailable = ENOBUFS,
+    /** Protocol not available */
+    OSResultProtocolNotAvailable = ENOPROTOOPT,
+    /** Unknown protocol */
+    OSResultUnknownProtocol = EPROTONOSUPPORT,
+    /** Illegal byte sequence */
+    OSResultInvalidByteSequence = EILSEQ,
+    /** Value too large for defined data type */
+    OSResultOverflow = EOVERFLOW,
+    /** Operation canceled */
+    OSResultCancelled = ECANCELED,
+
 } OSResult;
 
 /**

--- a/libs/drivers/comm/comm.c
+++ b/libs/drivers/comm/comm.c
@@ -53,11 +53,9 @@ static bool SendCommand(CommObject* object, CommAddress address, uint8_t command
     return status;
 }
 
-static bool SendCommandWithResponse(
-    CommObject* object, CommAddress address, uint8_t command, uint8_t* outBuffer, uint8_t outBufferSize)
+static bool SendCommandWithResponse(CommObject* object, CommAddress address, uint8_t command, uint8_t* outBuffer, uint8_t outBufferSize)
 {
-    const I2C_TransferReturn_TypeDef result =
-        object->low.readProc(address, &command, sizeof(command), outBuffer, outBufferSize);
+    const I2C_TransferReturn_TypeDef result = object->low.readProc(address, &command, sizeof(command), outBuffer, outBufferSize);
     const bool status = (result == i2cTransferDone);
     if (!status)
     {
@@ -79,7 +77,7 @@ OSResult CommInitialize(CommObject* comm, const CommLowInterface* lowerInterface
     }
     else
     {
-        return OSResultOutOfResources;
+        return OSResultNotEnoughMemory;
     }
 }
 
@@ -194,8 +192,7 @@ bool CommGetReceiverTelemetry(CommObject* comm, CommReceiverTelemetry* telemetry
 bool CommGetTransmitterTelemetry(CommObject* comm, CommTransmitterTelemetry* telemetry)
 {
     uint8_t buffer[sizeof(CommTransmitterTelemetry)];
-    const bool status =
-        SendCommandWithResponse(comm, CommTransmitter, TransmitterGetTelemetry, buffer, COUNT_OF(buffer));
+    const bool status = SendCommandWithResponse(comm, CommTransmitter, TransmitterGetTelemetry, buffer, COUNT_OF(buffer));
     if (!status)
     {
         return status;
@@ -273,10 +270,7 @@ bool CommSendFrame(CommObject* comm, uint8_t* data, uint8_t length)
     uint8_t cmd[255];
     if (length > COMM_MAX_FRAME_CONTENTS_SIZE)
     {
-        LOGF(LOG_LEVEL_ERROR,
-            "Frame payload is too long. Allowed: %d, Requested: '%d'.",
-            COMM_MAX_FRAME_CONTENTS_SIZE,
-            length);
+        LOGF(LOG_LEVEL_ERROR, "Frame payload is too long. Allowed: %d, Requested: '%d'.", COMM_MAX_FRAME_CONTENTS_SIZE, length);
         return false;
     }
 
@@ -284,8 +278,7 @@ bool CommSendFrame(CommObject* comm, uint8_t* data, uint8_t length)
     memcpy(cmd + 1, data, length);
     uint8_t remainingBufferSize;
 
-    const bool status =
-        (comm->low.readProc(CommTransmitter, cmd, length + 1, &remainingBufferSize, 1) == i2cTransferDone);
+    const bool status = (comm->low.readProc(CommTransmitter, cmd, length + 1, &remainingBufferSize, 1) == i2cTransferDone);
     if (!status)
     {
         LOG(LOG_LEVEL_ERROR, "[comm] Failed to send frame");
@@ -340,8 +333,7 @@ bool CommGetTransmitterState(CommObject* comm, CommTransmitterState* state)
 {
     uint8_t command = TransmitterGetState;
     uint8_t response;
-    const bool status = (comm->low.readProc(CommTransmitter, &command, sizeof(command), &response, sizeof(response)) ==
-        i2cTransferDone);
+    const bool status = (comm->low.readProc(CommTransmitter, &command, sizeof(command), &response, sizeof(response)) == i2cTransferDone);
     if (!status)
     {
         return false;
@@ -402,8 +394,7 @@ static void CommTask(void* param)
     CommPollHardware(comm);
     for (;;)
     {
-        const OSEventBits result =
-            System.EventGroupWaitForBits(comm->commTaskFlags, TaskFlagPauseRequest, false, true, 10000);
+        const OSEventBits result = System.EventGroupWaitForBits(comm->commTaskFlags, TaskFlagPauseRequest, false, true, 10000);
         if (result == TaskFlagPauseRequest)
         {
             LOG(LOG_LEVEL_WARNING, "Comm task paused");

--- a/libs/fs/Include/fs/fs.h
+++ b/libs/fs/Include/fs/fs.h
@@ -66,11 +66,17 @@ typedef enum {
     /** Open file only if it already exist, fail if it does not exist. */
     FsOpenExisting = 0,
 
+    /** Opens a file and truncates it so that its size is zero bytes, only if it exists. */
+    FsOpenTruncateExisting = O_TRUNC,
+
     /** Open file, create a new one if it does not exist. */
     FsOpenAlways = O_CREAT,
 
     /** Always create new file, if it exists truncate its content to zero. */
-    FsOpenCreateAlways = O_CREAT | O_EXCL | O_TRUNC,
+    FsOpenCreateAlways = O_CREAT | O_TRUNC,
+
+    /** Creates a new file, only if it does not already exist, fail if it exists. */
+    FsOpenCreateNew = O_CREAT | O_EXCL,
 
     /** If set, the file offset shall be set to the end of the file prior to each write. */
     FsOpenAppend = O_APPEND,

--- a/libs/fs/Include/fs/fs.h
+++ b/libs/fs/Include/fs/fs.h
@@ -161,12 +161,6 @@ typedef struct FileSystemTag
      * @return Operation status.
      */
     OSResult (*closeDirectory)(FileSystem* fileSystem, FSDirectoryHandle directory);
-
-    /**
-     * @brief Gets last error code
-     * @return Error code, @see errno.h
-     */
-    int (*getLastError)(FileSystem* fileSystem);
 } FileSystem;
 
 /**

--- a/libs/fs/Include/fs/fs.h
+++ b/libs/fs/Include/fs/fs.h
@@ -13,7 +13,7 @@ EXTERNC_BEGIN
 /**
  * @defgroup fs File system
  *
- * @brief File system API. POSIX-compatible
+ * @brief File system API.
  *
  * Wrappers for YAFFS file system.
  * Partitions:
@@ -40,8 +40,19 @@ typedef struct
     /** Operation status. */
     OSResult Status;
     /** Opened file handle. */
-    FSFileHandle FileHandle;
-} FSOpenResult;
+    FSFileHandle Handle;
+} FSFileOpenResult;
+
+/**
+ * @brief Type that represents directory opening status.
+ */
+typedef struct
+{
+    /** Operation status. */
+    OSResult Status;
+    /** Handle to the opened directory. */
+    FSDirectoryHandle Handle;
+} FSDirectoryOpenResult;
 
 /**
  * @brief Type that represents file read/write operation status.
@@ -86,9 +97,9 @@ typedef enum {
  * @brief Enumerator of all possible file access modes.
  */
 typedef enum {
-    /** Open for reading only. */
+    /** Open only for reading. */
     FsReadOnly = O_RDONLY,
-    /** Open for writing only. */
+    /** Open only for writing. */
     FsWriteOnly = O_WRONLY,
     /** Open for reading and writing. */
     FsReadWrite = O_RDWR,
@@ -101,15 +112,17 @@ typedef struct FileSystemTag
 {
     /**
      * @brief Opens file
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] path Path to file
      * @param[in] openFlag File opening flags. @see FSFileOpenFlags for details.
      * @param[in] accessMode Requested file access mode. @see FSFileAccessMode for details.
-     * @return Operation status. @see FSOpenResult for details.
+     * @return Operation status. @see FSFileOpenResult for details.
      */
-    FSOpenResult (*open)(FileSystem* fileSystem, const char* path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode);
+    FSFileOpenResult (*open)(FileSystem* fileSystem, const char* path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode);
 
     /**
      * @brief Truncates file to given size
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] file File handle
      * @param[in] length Desired length
      * @return Operation status.
@@ -118,6 +131,7 @@ typedef struct FileSystemTag
 
     /**
      * @brief Writes data to file
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] file File handle
      * @param[in] buffer Data buffer
      * @param[in] size Size of data
@@ -127,6 +141,7 @@ typedef struct FileSystemTag
 
     /**
      * @brief Reads data from file
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] file File handle
      * @param[out] buffer Data buffer
      * @param[in] size Size of data
@@ -136,6 +151,7 @@ typedef struct FileSystemTag
 
     /**
      * @brief Closes file
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] file File handle
      * @return Operation status.
      */
@@ -143,13 +159,15 @@ typedef struct FileSystemTag
 
     /**
      * @brief Opens directory
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] dirname Directory path
-     * @return Directory handle on success. NULL on error.
+     * @return Directory handle on success. @see FSDirectoryOpenResult for details.
      */
-    FSDirectoryHandle (*openDirectory)(FileSystem* fileSystem, const char* dirname);
+    FSDirectoryOpenResult (*openDirectory)(FileSystem* fileSystem, const char* dirname);
 
     /**
-     * @brief Reads name of next entry in directory
+     * @brief Reads name of next entry in directory.
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] directory Directory handle
      * @return Entry name. NULL if no more entries found.
      */
@@ -157,6 +175,7 @@ typedef struct FileSystemTag
 
     /**
      * @brief Closes directory
+     * @param[in] fileSystem FileSystem interface for accessing files.
      * @param[in] directory Directory handle
      * @return Operation status.
      */

--- a/libs/fs/extension.c
+++ b/libs/fs/extension.c
@@ -14,7 +14,7 @@ bool FileSystemSaveToFile(FileSystem* fs, const char* file, const uint8_t* buffe
     const bool status = OS_RESULT_SUCCEEDED(writeResult.Status) && writeResult.BytesTransferred == length;
     if (!status)
     {
-        LOGF(LOG_LEVEL_WARNING, "Unable to update file: %s. Status: 0x%08x", file, fs->getLastError(fs));
+        LOGF(LOG_LEVEL_WARNING, "Unable to update file: %s. Status: 0x%08x", file, writeResult.Status);
     }
 
     fs->close(fs, result.FileHandle);
@@ -30,11 +30,11 @@ bool FileSystemReadFile(FileSystem* fs, const char* const filePath, uint8_t* buf
         return false;
     }
 
-    const FSIOResult writeResult = fs->read(fs, result.FileHandle, buffer, length);
-    const bool status = OS_RESULT_SUCCEEDED(writeResult.Status) && writeResult.BytesTransferred == length;
+    const FSIOResult readResult = fs->read(fs, result.FileHandle, buffer, length);
+    const bool status = OS_RESULT_SUCCEEDED(readResult.Status) && readResult.BytesTransferred == length;
     if (!status)
     {
-        LOGF(LOG_LEVEL_WARNING, "Unable to read file: %s. Status: 0x%08x", filePath, fs->getLastError(fs));
+        LOGF(LOG_LEVEL_WARNING, "Unable to read file: %s. Status: 0x%08x", filePath, readResult.Status);
     }
 
     fs->close(fs, result.FileHandle);

--- a/libs/fs/extension.c
+++ b/libs/fs/extension.c
@@ -3,40 +3,40 @@
 
 bool FileSystemSaveToFile(FileSystem* fs, const char* file, const uint8_t* buffer, FSFileSize length)
 {
-    const FSOpenResult result = fs->open(fs, file, FsOpenCreateAlways, FsWriteOnly);
+    const FSFileOpenResult result = fs->open(fs, file, FsOpenCreateAlways, FsWriteOnly);
     if (OS_RESULT_FAILED(result.Status))
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to open file: %s", file);
         return false;
     }
 
-    const FSIOResult writeResult = fs->write(fs, result.FileHandle, buffer, length);
+    const FSIOResult writeResult = fs->write(fs, result.Handle, buffer, length);
     const bool status = OS_RESULT_SUCCEEDED(writeResult.Status) && writeResult.BytesTransferred == length;
     if (!status)
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to update file: %s. Status: 0x%08x", file, writeResult.Status);
     }
 
-    fs->close(fs, result.FileHandle);
+    fs->close(fs, result.Handle);
     return status;
 }
 
 bool FileSystemReadFile(FileSystem* fs, const char* const filePath, uint8_t* buffer, FSFileSize length)
 {
-    const FSOpenResult result = fs->open(fs, filePath, FsOpenExisting, FsReadOnly);
+    const FSFileOpenResult result = fs->open(fs, filePath, FsOpenExisting, FsReadOnly);
     if (OS_RESULT_FAILED(result.Status))
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to open file: %s", filePath);
         return false;
     }
 
-    const FSIOResult readResult = fs->read(fs, result.FileHandle, buffer, length);
+    const FSIOResult readResult = fs->read(fs, result.Handle, buffer, length);
     const bool status = OS_RESULT_SUCCEEDED(readResult.Status) && readResult.BytesTransferred == length;
     if (!status)
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to read file: %s. Status: 0x%08x", filePath, readResult.Status);
     }
 
-    fs->close(fs, result.FileHandle);
+    fs->close(fs, result.Handle);
     return status;
 }

--- a/libs/fs/extension.c
+++ b/libs/fs/extension.c
@@ -1,42 +1,42 @@
 #include "fs.h"
 #include "logger/logger.h"
 
-bool FileSystemSaveToFile(FileSystem* fs, const char* file, const uint8_t* buffer, uint32_t length)
+bool FileSystemSaveToFile(FileSystem* fs, const char* file, const uint8_t* buffer, FSFileSize length)
 {
-    const FSFileHandle handle = fs->open(file, O_WRONLY | O_CREAT, S_IRWXU);
-    if (handle == -1)
+    const FSOpenResult result = fs->open(fs, file, FsOpenCreateAlways, FsWriteOnly);
+    if (OS_RESULT_FAILED(result.Status))
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to open file: %s", file);
         return false;
     }
 
-    const uint32_t result = fs->write(handle, buffer, length);
-    const bool status = result == length;
+    const FSIOResult writeResult = fs->write(fs, result.FileHandle, buffer, length);
+    const bool status = OS_RESULT_SUCCEEDED(writeResult.Status) && writeResult.BytesTransferred == length;
     if (!status)
     {
-        LOGF(LOG_LEVEL_WARNING, "Unable to update file: %s. Status: 0x%08x", file, fs->getLastError());
+        LOGF(LOG_LEVEL_WARNING, "Unable to update file: %s. Status: 0x%08x", file, fs->getLastError(fs));
     }
 
-    fs->close(handle);
+    fs->close(fs, result.FileHandle);
     return status;
 }
 
-bool FileSystemReadFile(FileSystem* fs, const char* const filePath, uint8_t* buffer, uint32_t length)
+bool FileSystemReadFile(FileSystem* fs, const char* const filePath, uint8_t* buffer, FSFileSize length)
 {
-    const FSFileHandle handle = fs->open(filePath, O_RDONLY, S_IRWXU);
-    if (handle == -1)
+    const FSOpenResult result = fs->open(fs, filePath, FsOpenExisting, FsReadOnly);
+    if (OS_RESULT_FAILED(result.Status))
     {
         LOGF(LOG_LEVEL_WARNING, "Unable to open file: %s", filePath);
         return false;
     }
 
-    const uint32_t read = fs->read(handle, buffer, length);
-    const bool status = read == length;
+    const FSIOResult writeResult = fs->read(fs, result.FileHandle, buffer, length);
+    const bool status = OS_RESULT_SUCCEEDED(writeResult.Status) && writeResult.BytesTransferred == length;
     if (!status)
     {
-        LOGF(LOG_LEVEL_WARNING, "Unable to read file: %s. Status: 0x%08x", filePath, fs->getLastError());
+        LOGF(LOG_LEVEL_WARNING, "Unable to read file: %s. Status: 0x%08x", filePath, fs->getLastError(fs));
     }
 
-    fs->close(handle);
+    fs->close(fs, result.FileHandle);
     return status;
 }

--- a/libs/fs/fs.c
+++ b/libs/fs/fs.c
@@ -5,8 +5,23 @@
 
 extern void YaffsGlueInit(void);
 
-static char* YaffsReadDirectory(FSDirectoryHandle directory)
+static OSResult YaffsTranslateError(int error)
 {
+    // TODO determine list of possible errors and integrate them into OSResult enumeration
+    // so they can be directly mapped
+    if (error == -1)
+    {
+        return OSResultInvalidOperation;
+    }
+    else
+    {
+        return OSResultSuccess;
+    }
+}
+
+static char* YaffsReadDirectory(FileSystem* fileSystem, FSDirectoryHandle directory)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
     struct yaffs_dirent* entry = yaffs_readdir((yaffs_DIR*)directory);
     if (entry == NULL)
     {
@@ -18,14 +33,73 @@ static char* YaffsReadDirectory(FSDirectoryHandle directory)
     }
 }
 
-static FSDirectoryHandle YaffsOpenDirectory(const char* directory)
+static FSOpenResult YaffsOpen(FileSystem* fileSystem, const char* path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode)
 {
+    UNREFERENCED_PARAMETER(fileSystem);
+    FSOpenResult result;
+    const int status = yaffs_open(path, openFlag | accessMode, S_IRWXU);
+    if (status == -1)
+    {
+        result.Status = OSResultInvalidOperation;
+        result.FileHandle = 0;
+    }
+    else
+    {
+        result.Status = OSResultSuccess;
+        result.FileHandle = status;
+    }
+
+    return result;
+}
+
+static OSResult YaffsTruncate(FileSystem* fileSystem, FSFileHandle file, FSFileSize length)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
+    return YaffsTranslateError(yaffs_ftruncate(file, length));
+}
+
+static FSIOResult YaffsWrite(FileSystem* fileSystem, FSFileHandle file, const void* buffer, FSFileSize size)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
+    FSIOResult result;
+    const int status = yaffs_write(file, buffer, size);
+    result.Status = YaffsTranslateError(status);
+    result.BytesTransferred = status;
+    return result;
+}
+
+static FSIOResult YaffsRead(FileSystem* fileSystem, FSFileHandle file, void* buffer, FSFileSize size)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
+    FSIOResult result;
+    const int status = yaffs_read(file, buffer, size);
+    result.Status = YaffsTranslateError(status);
+    result.BytesTransferred = status;
+    return result;
+}
+
+static OSResult YaffsClose(FileSystem* fileSystem, FSFileHandle file)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
+    return YaffsTranslateError(yaffs_close(file));
+}
+
+static FSDirectoryHandle YaffsOpenDirectory(FileSystem* fileSystem, const char* directory)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
     return (FSDirectoryHandle)yaffs_opendir(directory);
 }
 
-static int YaffsCloseDirectory(FSDirectoryHandle directory)
+static OSResult YaffsCloseDirectory(FileSystem* fileSystem, FSDirectoryHandle directory)
 {
-    return yaffs_closedir((yaffs_DIR*)directory);
+    UNREFERENCED_PARAMETER(fileSystem);
+    return YaffsTranslateError(yaffs_closedir((yaffs_DIR*)directory));
+}
+
+static int YaffsGetLastError(FileSystem* fileSystem)
+{
+    UNREFERENCED_PARAMETER(fileSystem);
+    return yaffs_get_error();
 }
 
 bool FileSystemInitialize(FileSystem* fs, struct yaffs_dev* rootDevice)
@@ -34,14 +108,15 @@ bool FileSystemInitialize(FileSystem* fs, struct yaffs_dev* rootDevice)
 
     yaffs_add_device(rootDevice);
 
-    fs->open = yaffs_open;
-    fs->write = yaffs_write;
-    fs->close = yaffs_close;
-    fs->read = yaffs_read;
+    fs->open = YaffsOpen;
+    fs->write = YaffsWrite;
+    fs->close = YaffsClose;
+    fs->read = YaffsRead;
     fs->openDirectory = YaffsOpenDirectory;
     fs->readDirectory = YaffsReadDirectory;
     fs->closeDirectory = YaffsCloseDirectory;
-    fs->ftruncate = yaffs_ftruncate;
+    fs->ftruncate = YaffsTruncate;
+    fs->getLastError = YaffsGetLastError;
 
     int result = yaffs_mount("/");
 

--- a/libs/fs/fs.c
+++ b/libs/fs/fs.c
@@ -5,17 +5,15 @@
 
 extern void YaffsGlueInit(void);
 
-static OSResult YaffsTranslateError(int error)
+static inline OSResult YaffsTranslateError(int error)
 {
-    // TODO determine list of possible errors and integrate them into OSResult enumeration
-    // so they can be directly mapped
-    if (error == -1)
+    if (error != -1)
     {
-        return OSResultInvalidOperation;
+        return OSResultSuccess;
     }
     else
     {
-        return OSResultSuccess;
+        return (OSResult)yaffs_get_error();
     }
 }
 
@@ -96,12 +94,6 @@ static OSResult YaffsCloseDirectory(FileSystem* fileSystem, FSDirectoryHandle di
     return YaffsTranslateError(yaffs_closedir((yaffs_DIR*)directory));
 }
 
-static int YaffsGetLastError(FileSystem* fileSystem)
-{
-    UNREFERENCED_PARAMETER(fileSystem);
-    return yaffs_get_error();
-}
-
 bool FileSystemInitialize(FileSystem* fs, struct yaffs_dev* rootDevice)
 {
     YaffsGlueInit();
@@ -116,7 +108,6 @@ bool FileSystemInitialize(FileSystem* fs, struct yaffs_dev* rootDevice)
     fs->readDirectory = YaffsReadDirectory;
     fs->closeDirectory = YaffsCloseDirectory;
     fs->ftruncate = YaffsTruncate;
-    fs->getLastError = YaffsGetLastError;
 
     int result = yaffs_mount("/");
 

--- a/libs/logger/Logger.c
+++ b/libs/logger/Logger.c
@@ -52,6 +52,7 @@ typedef struct
 /** @brief Global logger object. */
 static Logger logger = {0};
 
+/** @brief Array for converting log level to string. */
 static const char* const levelMap[] = {"[Always]  ", "[Fatal]   ", "[Error]   ", "[Warning] ", "[Info]    ", "[Debug]   ", "[Trace]   "};
 
 static_assert(LOG_LEVEL_ALWAYS == 0, "Fix level conversion map for level: Always");
@@ -62,6 +63,12 @@ static_assert(LOG_LEVEL_INFO == 4, "Fix level conversion map for level: Info");
 static_assert(LOG_LEVEL_DEBUG == 5, "Fix level conversion map for level: Debug");
 static_assert(LOG_LEVEL_TRACE == 6, "Fix level conversion map for level: Trace");
 
+/**
+ * @brief Convert log level to string.
+ * @param[in] level Logging level to convert.
+ * @return String representation of logging level.
+ * @remark Logging level strings are already aligned. If passed log level is not known then the default string will be returned.
+ */
 static const char* LogConvertLevelToString(enum LogLevel level)
 {
     if (level >= COUNT_OF(levelMap))
@@ -110,6 +117,12 @@ void LogRemoveEndpoint(LoggerProcedure endpoint)
     }
 }
 
+/**
+ * @brief This procedure determines if passed logging level is considered to be enabled on configured logging level.
+ * @param[in] requestedLogLEvel Queried log level.
+ * @param[in] currentLogLevel Currently used logging level
+ * @return True Then passed logging level is enabled, false otherwise.
+ */
 static inline bool CanLogAtLevel(const enum LogLevel requestedLogLEvel, const enum LogLevel currentLogLevel)
 {
     return requestedLogLEvel <= currentLogLevel;

--- a/libs/os/os.c
+++ b/libs/os/os.c
@@ -22,7 +22,7 @@ static OSResult TaskCreate(OSTaskProcedure entryPoint, //
     const BaseType_t result = xTaskCreate(entryPoint, taskName, stackSize, taskParameter, priority, taskHandle);
     if (result != pdPASS)
     {
-        return OSResultOutOfResources;
+        return OSResultNotEnoughMemory;
     }
     else
     {

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -39,7 +39,7 @@ typedef struct
  */
 typedef struct
 {
-    uint64_t value;
+    uint64_t value; ///< Time span length in milliseconds.
 } TimeSpan;
 
 /**
@@ -47,7 +47,7 @@ typedef struct
  */
 typedef struct
 {
-    int64_t value;
+    int64_t value; ///< Time shift length in milliseconds.
 } TimeShift;
 
 /**

--- a/src/commands/file_system.c
+++ b/src/commands/file_system.c
@@ -9,9 +9,9 @@ void FSListFiles(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
 
-    FSDirectoryHandle dir = Main.fs.openDirectory(&Main.fs, argv[0]);
+    const FSDirectoryOpenResult result = Main.fs.openDirectory(&Main.fs, argv[0]);
 
-    if (dir == NULL)
+    if (OS_RESULT_FAILED(result.Status))
     {
         TerminalPuts("Error");
         TerminalSendNewLine();
@@ -19,6 +19,7 @@ void FSListFiles(uint16_t argc, char* argv[])
     }
 
     char* entry;
+    FSDirectoryHandle dir = result.Handle;
     while ((entry = Main.fs.readDirectory(&Main.fs, dir)) != NULL)
     {
         TerminalPuts(entry);
@@ -32,7 +33,7 @@ void FSWriteFile(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
 
-    const FSOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenCreateAlways, FsWriteOnly);
+    const FSFileOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenCreateAlways, FsWriteOnly);
     if (OS_RESULT_FAILED(result.Status))
     {
         TerminalPuts("Error");
@@ -40,7 +41,7 @@ void FSWriteFile(uint16_t argc, char* argv[])
         return;
     }
 
-    const FSFileHandle file = result.FileHandle;
+    const FSFileHandle file = result.Handle;
     Main.fs.ftruncate(&Main.fs, file, 0);
     Main.fs.write(&Main.fs, file, argv[1], strlen(argv[1]));
     Main.fs.close(&Main.fs, file);
@@ -49,7 +50,7 @@ void FSWriteFile(uint16_t argc, char* argv[])
 void FSReadFile(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
-    const FSOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenExisting, FsReadOnly);
+    const FSFileOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenExisting, FsReadOnly);
     if (OS_RESULT_FAILED(result.Status))
     {
         TerminalPuts("Error");
@@ -59,7 +60,7 @@ void FSReadFile(uint16_t argc, char* argv[])
 
     char buffer[100];
     memset(buffer, 0, sizeof(buffer));
-    const FSFileHandle file = result.FileHandle;
+    const FSFileHandle file = result.Handle;
     Main.fs.read(&Main.fs, file, buffer, sizeof(buffer));
     Main.fs.close(&Main.fs, file);
 

--- a/src/commands/file_system.c
+++ b/src/commands/file_system.c
@@ -9,9 +9,9 @@ void FSListFiles(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
 
-    FSDirectoryHandle dir = Main.fs.openDirectory(argv[0]);
+    FSDirectoryHandle dir = Main.fs.openDirectory(&Main.fs, argv[0]);
 
-    if (dir == -1)
+    if (dir == NULL)
     {
         TerminalPuts("Error");
         TerminalSendNewLine();
@@ -19,39 +19,38 @@ void FSListFiles(uint16_t argc, char* argv[])
     }
 
     char* entry;
-    while ((entry = Main.fs.readDirectory(dir)) != NULL)
+    while ((entry = Main.fs.readDirectory(&Main.fs, dir)) != NULL)
     {
         TerminalPuts(entry);
         TerminalSendNewLine();
     }
 
-    Main.fs.closeDirectory(dir);
+    Main.fs.closeDirectory(&Main.fs, dir);
 }
 
 void FSWriteFile(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
 
-    FSFileHandle file = Main.fs.open(argv[0], O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
-
-    if (file == -1)
+    const FSOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenCreateAlways, FsWriteOnly);
+    if (OS_RESULT_FAILED(result.Status))
     {
         TerminalPuts("Error");
         TerminalSendNewLine();
         return;
     }
 
-    Main.fs.ftruncate(file, 0);
-    Main.fs.write(file, argv[1], strlen(argv[1]));
-    Main.fs.close(file);
+    const FSFileHandle file = result.FileHandle;
+    Main.fs.ftruncate(&Main.fs, file, 0);
+    Main.fs.write(&Main.fs, file, argv[1], strlen(argv[1]));
+    Main.fs.close(&Main.fs, file);
 }
 
 void FSReadFile(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
-    FSFileHandle file = Main.fs.open(argv[0], O_RDONLY, S_IRWXU);
-
-    if (file == -1)
+    const FSOpenResult result = Main.fs.open(&Main.fs, argv[0], FsOpenExisting, FsReadOnly);
+    if (OS_RESULT_FAILED(result.Status))
     {
         TerminalPuts("Error");
         TerminalSendNewLine();
@@ -59,12 +58,10 @@ void FSReadFile(uint16_t argc, char* argv[])
     }
 
     char buffer[100];
-
     memset(buffer, 0, sizeof(buffer));
-
-    Main.fs.read(file, buffer, sizeof(buffer));
-
-    Main.fs.close(file);
+    const FSFileHandle file = result.FileHandle;
+    Main.fs.read(&Main.fs, file, buffer, sizeof(buffer));
+    Main.fs.close(&Main.fs, file);
 
     buffer[99] = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -220,7 +220,7 @@ int main(void)
     GPIO_PinOutSet(LED_PORT, LED1);
 
     System.CreateTask(BlinkLed0, "Blink0", 512, NULL, tskIDLE_PRIORITY + 1, NULL);
-    // System.CreateTask(ADXRS, "ADXRS", 512, NULL, tskIDLE_PRIORITY + 2, NULL);
+    System.CreateTask(ADXRS, "ADXRS", 512, NULL, tskIDLE_PRIORITY + 2, NULL);
     System.CreateTask(ObcInitTask, "Init", 512, &Main, tskIDLE_PRIORITY + 16, &Main.initTask);
     System.RunScheduler();
 

--- a/src/main.c
+++ b/src/main.c
@@ -4,9 +4,9 @@
 #include <em_cmu.h>
 #include <em_dbg.h>
 #include <em_device.h>
+#include <em_emu.h>
 #include <em_gpio.h>
 #include <em_system.h>
-#include <em_emu.h>
 
 #include <FreeRTOS.h>
 #include <FreeRTOSConfig.h>
@@ -24,15 +24,14 @@
 #include "swo/swo.h"
 #include "system.h"
 
-#include "terminal.h"
-#include "adxrs453/adxrs453.h"
 #include <spidrv.h>
+#include "adxrs453/adxrs453.h"
+#include "terminal.h"
 
 #include "fs/fs.h"
 #include "storage/nand.h"
 #include "storage/nand_driver.h"
 #include "storage/storage.h"
-
 
 OBC Main;
 
@@ -137,48 +136,54 @@ static void FrameHandler(CommObject* comm, CommFrame* frame, void* context)
     CommSendFrame(comm, (uint8_t*)"PONG", 4);
 }
 
+void ADXRS(void* param)
+{
+    UNREFERENCED_PARAMETER(param);
+    SPIDRV_HandleData_t handleData;
+    SPIDRV_Handle_t handle = &handleData;
+    SPIDRV_Init_t initData = ADXRS453_SPI;
+    SPIDRV_Init(handle, &initData);
+    GyroInterface_t interface;
+    interface.writeProc = SPISendB;
+    interface.readProc = SPISendRecvB;
+    ADXRS453_Obj_t gyro;
+    gyro.pinLocations = (ADXRS453_PinLocations_t)GYRO0;
+    gyro.interface = interface;
+    ADXRS453_Obj_t gyro1;
+    gyro1.pinLocations = (ADXRS453_PinLocations_t)GYRO1;
+    gyro1.interface = interface;
+    ADXRS453_Obj_t gyro2;
+    gyro2.pinLocations = (ADXRS453_PinLocations_t)GYRO2;
+    gyro2.interface = interface;
+    ADXRS453_Init(&gyro, handle);
+    ADXRS453_Init(&gyro1, handle);
+    ADXRS453_Init(&gyro2, handle);
 
-void ADXRS(void * param){
-	UNREFERENCED_PARAMETER(param);
-	SPIDRV_HandleData_t handleData;
-	SPIDRV_Handle_t handle = &handleData;
-	SPIDRV_Init_t initData = ADXRS453_SPI;
-	SPIDRV_Init( handle, &initData );
-	GyroInterface_t interface;
-	interface.writeProc=SPISendB;
-	interface.readProc=SPISendRecvB;
-	ADXRS453_Obj_t gyro;
-	gyro.pinLocations = (ADXRS453_PinLocations_t)GYRO0;
-	gyro.interface=interface;
-	ADXRS453_Obj_t gyro1;
-	gyro1.pinLocations = (ADXRS453_PinLocations_t)GYRO1;
-	gyro1.interface=interface;
-	ADXRS453_Obj_t gyro2;
-	gyro2.pinLocations = (ADXRS453_PinLocations_t)GYRO2;
-	gyro2.interface=interface;
-	ADXRS453_Init(&gyro,handle);
-	ADXRS453_Init(&gyro1,handle);
-	ADXRS453_Init(&gyro2,handle);
-
-
-	while(1){
-		SPI_TransferReturn_t rate=ADXRS453_GetRate(&gyro,handle);
-		SPI_TransferReturn_t temp=ADXRS453_GetTemperature(&gyro,handle);
-		LOGF(LOG_LEVEL_INFO, "gyro 0 temp: %d ' celcius rate: %d '/sec rotation\n", (int)temp.result.sensorResult, (int)rate.result.sensorResult);
-		rate=ADXRS453_GetRate(&gyro1,handle);
-		temp=ADXRS453_GetTemperature(&gyro1,handle);
-		LOGF(LOG_LEVEL_INFO, "gyro 1 temp: %d ' celcius rate: %d '/sec rotation\n", (int)temp.result.sensorResult, (int)rate.result.sensorResult);
-		rate=ADXRS453_GetRate(&gyro2,handle);
-		temp=ADXRS453_GetTemperature(&gyro2,handle);
-		LOGF(LOG_LEVEL_INFO, "gyro 2 temp: %d ' celcius rate: %d '/sec rotation\n", (int)temp.result.sensorResult, (int)rate.result.sensorResult);
-		vTaskDelay(10 / portTICK_PERIOD_MS);
-	}
-
-
+    while (1)
+    {
+        SPI_TransferReturn_t rate = ADXRS453_GetRate(&gyro, handle);
+        SPI_TransferReturn_t temp = ADXRS453_GetTemperature(&gyro, handle);
+        LOGF(LOG_LEVEL_INFO,
+            "gyro 0 temp: %d ' celcius rate: %d '/sec rotation\n",
+            (int)temp.result.sensorResult,
+            (int)rate.result.sensorResult);
+        rate = ADXRS453_GetRate(&gyro1, handle);
+        temp = ADXRS453_GetTemperature(&gyro1, handle);
+        LOGF(LOG_LEVEL_INFO,
+            "gyro 1 temp: %d ' celcius rate: %d '/sec rotation\n",
+            (int)temp.result.sensorResult,
+            (int)rate.result.sensorResult);
+        rate = ADXRS453_GetRate(&gyro2, handle);
+        temp = ADXRS453_GetTemperature(&gyro2, handle);
+        LOGF(LOG_LEVEL_INFO,
+            "gyro 2 temp: %d ' celcius rate: %d '/sec rotation\n",
+            (int)temp.result.sensorResult,
+            (int)rate.result.sensorResult);
+        vTaskDelay(10 / portTICK_PERIOD_MS);
+    }
 }
 int main(void)
 {
-
     memset(&Main, 0, sizeof(Main));
     CHIP_Init();
 
@@ -211,18 +216,15 @@ int main(void)
     GPIO_PinModeSet(LED_PORT, LED1, gpioModePushPullDrive, 1);
     GPIO_DriveModeSet(LED_PORT, gpioDriveModeLowest);
 
-
     GPIO_PinOutSet(LED_PORT, LED0);
     GPIO_PinOutSet(LED_PORT, LED1);
 
-
     System.CreateTask(BlinkLed0, "Blink0", 512, NULL, tskIDLE_PRIORITY + 1, NULL);
-    System.CreateTask(ADXRS, "ADXRS", 512, NULL, tskIDLE_PRIORITY + 2, NULL);
+    // System.CreateTask(ADXRS, "ADXRS", 512, NULL, tskIDLE_PRIORITY + 2, NULL);
     System.CreateTask(ObcInitTask, "Init", 512, &Main, tskIDLE_PRIORITY + 16, &Main.initTask);
     System.RunScheduler();
 
     GPIO_PinOutToggle(LED_PORT, LED0);
-
 
     return 0;
 }

--- a/unit_tests/mock/FsMock.cpp
+++ b/unit_tests/mock/FsMock.cpp
@@ -1,7 +1,7 @@
 #include "FsMock.hpp"
 #include <utility>
 
-static FSOpenResult FsOpen(FileSystem* fileSystem, const char* path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode)
+static FSFileOpenResult FsOpen(FileSystem* fileSystem, const char* path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode)
 {
     auto fsMock = static_cast<FsMock*>(fileSystem);
     return fsMock->Open(path, openFlag, accessMode);
@@ -43,19 +43,19 @@ FsMock::FsMock()
     close = FsClose;
 }
 
-FSOpenResult MakeOpenedFile(int handle)
+FSFileOpenResult MakeOpenedFile(int handle)
 {
-    FSOpenResult result;
+    FSFileOpenResult result;
     result.Status = OSResultSuccess;
-    result.FileHandle = handle;
+    result.Handle = handle;
     return result;
 }
 
-FSOpenResult MakeOpenedFile(OSResult status)
+FSFileOpenResult MakeOpenedFile(OSResult status)
 {
-    FSOpenResult result;
+    FSFileOpenResult result;
     result.Status = status;
-    result.FileHandle = -1;
+    result.Handle = -1;
     return result;
 }
 

--- a/unit_tests/mock/FsMock.cpp
+++ b/unit_tests/mock/FsMock.cpp
@@ -31,12 +31,6 @@ static OSResult FsClose(FileSystem* fileSystem, FSFileHandle file)
     return fsMock->Close(file);
 }
 
-static int FsGetLastError(FileSystem* fileSystem)
-{
-    auto fsMock = static_cast<FsMock*>(fileSystem);
-    return fsMock->GetLastError();
-}
-
 FsMock::FsMock()
 {
     open = FsOpen;
@@ -47,7 +41,6 @@ FsMock::FsMock()
     readDirectory = nullptr;
     closeDirectory = nullptr;
     close = FsClose;
-    getLastError = FsGetLastError;
 }
 
 FSOpenResult MakeOpenedFile(int handle)

--- a/unit_tests/mock/FsMock.hpp
+++ b/unit_tests/mock/FsMock.hpp
@@ -10,16 +10,16 @@
 struct FsMock : FileSystem
 {
     FsMock();
-    MOCK_METHOD3(Open, FSOpenResult(const std::string& path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode));
+    MOCK_METHOD3(Open, FSFileOpenResult(const std::string& path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode));
     MOCK_METHOD2(Truncate, OSResult(FSFileHandle file, FSFileSize length));
     MOCK_METHOD3(Write, FSIOResult(FSFileHandle file, const void* buffer, FSFileSize size));
     MOCK_METHOD3(Read, FSIOResult(FSFileHandle file, void* buffer, FSFileSize size));
     MOCK_METHOD1(Close, OSResult(FSFileHandle file));
 };
 
-FSOpenResult MakeOpenedFile(int handle);
+FSFileOpenResult MakeOpenedFile(int handle);
 
-FSOpenResult MakeOpenedFile(OSResult result);
+FSFileOpenResult MakeOpenedFile(OSResult result);
 
 FSIOResult MakeFSIOResult(int bytesTransfered);
 

--- a/unit_tests/mock/FsMock.hpp
+++ b/unit_tests/mock/FsMock.hpp
@@ -15,7 +15,6 @@ struct FsMock : FileSystem
     MOCK_METHOD3(Write, FSIOResult(FSFileHandle file, const void* buffer, FSFileSize size));
     MOCK_METHOD3(Read, FSIOResult(FSFileHandle file, void* buffer, FSFileSize size));
     MOCK_METHOD1(Close, OSResult(FSFileHandle file));
-    MOCK_METHOD0(GetLastError, int(void));
 };
 
 FSOpenResult MakeOpenedFile(int handle);

--- a/unit_tests/mock/FsMock.hpp
+++ b/unit_tests/mock/FsMock.hpp
@@ -7,33 +7,23 @@
 #include "gmock/gmock.h"
 #include "fs/fs.h"
 
-struct FsMock
+struct FsMock : FileSystem
 {
-    MOCK_METHOD3(Open, FSFileHandle(const std::string& path, int flags, int mode));
-    MOCK_METHOD2(Truncate, int(FSFileHandle file, int64_t length));
-    MOCK_METHOD3(Write, int(FSFileHandle file, const void* buffer, unsigned int size));
-    MOCK_METHOD3(Read, int(FSFileHandle file, void* buffer, unsigned int size));
-    MOCK_METHOD1(Close, int(FSFileHandle file));
+    FsMock();
+    MOCK_METHOD3(Open, FSOpenResult(const std::string& path, FSFileOpenFlags openFlag, FSFileAccessMode accessMode));
+    MOCK_METHOD2(Truncate, OSResult(FSFileHandle file, FSFileSize length));
+    MOCK_METHOD3(Write, FSIOResult(FSFileHandle file, const void* buffer, FSFileSize size));
+    MOCK_METHOD3(Read, FSIOResult(FSFileHandle file, void* buffer, FSFileSize size));
+    MOCK_METHOD1(Close, OSResult(FSFileHandle file));
     MOCK_METHOD0(GetLastError, int(void));
 };
 
-class FsMockReset
-{
-  public:
-    FsMockReset();
+FSOpenResult MakeOpenedFile(int handle);
 
-    FsMockReset(FsMockReset&& arg) noexcept;
+FSOpenResult MakeOpenedFile(OSResult result);
 
-    ~FsMockReset();
+FSIOResult MakeFSIOResult(int bytesTransfered);
 
-    FsMockReset& operator=(FsMockReset&& arg) noexcept;
-
-  private:
-    bool released;
-};
-
-extern FileSystem MockedFileSystem;
-
-FsMockReset InstallFileSystemMock(FsMock& mock);
+FSIOResult MakeFSIOResult(OSResult result, int bytesTransfered);
 
 #endif

--- a/unit_tests/os/os.cpp
+++ b/unit_tests/os/os.cpp
@@ -7,7 +7,7 @@ OS System;
 
 static IOS* OSProxy = nullptr;
 
-static OSResult TaskCreate(OSTaskProcedure entryPoint,
+static OSResult TaskCreate(OSTaskProcedure entryPoint, //
     const char* taskName,
     uint16_t stackSize,
     void* taskParameter,
@@ -20,7 +20,7 @@ static OSResult TaskCreate(OSTaskProcedure entryPoint,
     }
     else
     {
-        return OSResultOutOfResources;
+        return OSResultNotSupported;
     }
 }
 
@@ -116,11 +116,8 @@ static OSEventBits EventGroupClearBits(OSEventGroupHandle eventGroup, const OSEv
     return 0;
 }
 
-static OSEventBits EventGroupWaitForBits(OSEventGroupHandle eventGroup,
-    const OSEventBits bitsToWaitFor,
-    bool waitAll,
-    bool autoReset,
-    const OSTaskTimeSpan timeout)
+static OSEventBits EventGroupWaitForBits(
+    OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const OSTaskTimeSpan timeout)
 {
     if (OSProxy != nullptr)
     {

--- a/unit_tests/time/persistance.cpp
+++ b/unit_tests/time/persistance.cpp
@@ -24,7 +24,6 @@ class TimerPersistanceTest : public testing::Test
     testing::NiceMock<FsMock> fs;
     testing::NiceMock<OSMock> os;
     OSReset osGuard;
-    FsMockReset fsGuard;
 };
 
 TimeSpan TimerPersistanceTest::GetCurrentTime()
@@ -41,7 +40,6 @@ static void TimePassedProxy(void* /*context*/, TimePoint /*currentTime*/)
 TimerPersistanceTest::TimerPersistanceTest()
 {
     this->osGuard = InstallProxy(&os);
-    this->fsGuard = InstallFileSystemMock(fs);
     EXPECT_CALL(os, CreateBinarySemaphore()).WillOnce(Return(reinterpret_cast<void*>(1))).WillOnce(Return(reinterpret_cast<void*>(2)));
     ON_CALL(os, TakeSemaphore(_, _)).WillByDefault(Return(OSResultSuccess));
     ON_CALL(os, GiveSemaphore(_)).WillByDefault(Return(OSResultSuccess));
@@ -50,130 +48,133 @@ TimerPersistanceTest::TimerPersistanceTest()
 
 TEST_F(TimerPersistanceTest, TestReadingStateNoState)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingStateEmptyFiles)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultInvalidOperation)));
+    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(OSResultSuccess));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFiles)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(10));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(10)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             EXPECT_THAT(buffer, Ne(nullptr));
             if (buffer == nullptr)
             {
-                return -1;
+                return MakeFSIOResult(OSResultInvalidOperation);
             }
             else
             {
                 memset(buffer, 0x11, size);
-                return static_cast<int>(size);
+                return MakeFSIOResult(size);
             }
         }));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingSingleNonEmptyFile)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(1)).WillRepeatedly(Return(-1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(MakeOpenedFile(1))).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillOnce(Invoke([](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Invoke([](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memset(buffer, 0x11, size);
-            return size;
+            return MakeFSIOResult(size);
         }))
-        .WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+        .WillRepeatedly(Return(MakeFSIOResult(OSResultInvalidOperation)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingTwoNonEmptyFiles)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillOnce(Return(0))
-        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Return(MakeFSIOResult(0)))
+        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memset(buffer, 0x11, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingTwoExistingEmptyFiles)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(-1)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(MakeOpenedFile(OSResultNotFound))).WillRepeatedly(Return(MakeOpenedFile(1)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memset(buffer, 0x11, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFilesEndiannes)
 {
     const uint8_t expected[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillRepeatedly(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
-            EXPECT_THAT(size, Eq(8u));
+        .WillRepeatedly(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
+            EXPECT_THAT(size, Eq(8));
             if (size != 8)
             {
-                return -1;
+                return MakeFSIOResult(OSResultInvalidOperation);
             }
             else
             {
                 memcpy(buffer, expected, size);
-                return static_cast<int>(size);
+                return MakeFSIOResult(size);
             }
         }));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x8877665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFilesGetClosed)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(1)).WillOnce(Return(2)).WillOnce(Return(3));
-    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(-1));
+    EXPECT_CALL(fs, Open(_, _, _))
+        .WillOnce(Return(MakeOpenedFile(1)))
+        .WillOnce(Return(MakeOpenedFile(2)))
+        .WillOnce(Return(MakeOpenedFile(3)));
+    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultOutOfResources)));
     EXPECT_CALL(fs, Close(1)).Times(1);
     EXPECT_CALL(fs, Close(2)).Times(1);
     EXPECT_CALL(fs, Close(3)).Times(1);
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingThreeFilesTwoSame)
 {
     const uint8_t expected[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
     const uint8_t incorrect[] = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(_, _, _))
-        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memcpy(buffer, incorrect, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }))
-        .WillRepeatedly(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillRepeatedly(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memcpy(buffer, expected, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x8877665544332211ull)));
 }
 
@@ -182,62 +183,65 @@ TEST_F(TimerPersistanceTest, TestReadingThreeDifferentFiles)
     const uint8_t a[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x78};
     const uint8_t b[] = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
     const uint8_t c[] = {0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa};
-    EXPECT_CALL(fs, Open(_, _, _)).WillOnce(Return(1)).WillOnce(Return(2)).WillOnce(Return(3));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _))
+        .WillOnce(Return(MakeOpenedFile(1)))
+        .WillOnce(Return(MakeOpenedFile(2)))
+        .WillOnce(Return(MakeOpenedFile(3)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Read(Eq(1), _, _))
-        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memcpy(buffer, b, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
 
     EXPECT_CALL(fs, Read(Eq(2), _, _))
-        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memcpy(buffer, a, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
 
     EXPECT_CALL(fs, Read(Eq(3), _, _))
-        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, unsigned int size) {
+        .WillOnce(Invoke([=](FSFileHandle /*file*/, void* buffer, FSFileSize size) {
             memcpy(buffer, c, size);
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
 
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x7877665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateSaveError)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(0x44332211ull));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWriteError)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_CALL(fs, Close(_)).Times(9).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultInvalidOperation)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(0x44332211ull));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWrite)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
+    ON_CALL(fs, Close(_)).WillByDefault(Return(OSResultSuccess));
     EXPECT_CALL(fs, Write(_, _, _))
-        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, const void* buffer, unsigned int size) {
+        .WillRepeatedly(Invoke([](FSFileHandle /*file*/, const void* buffer, FSFileSize size) {
             uint8_t expected[] = {0x11, 0x22, 0x33, 0x44, 0x00, 0x00, 0x00, 0x00};
-            EXPECT_THAT(size, Eq(8u));
+            EXPECT_THAT(size, Eq(8));
             EXPECT_THAT(std::vector<uint8_t>(static_cast<const uint8_t*>(buffer), static_cast<const uint8_t*>(buffer) + size),
                 ::testing::ElementsAreArray(expected));
-            return static_cast<int>(size);
+            return MakeFSIOResult(size);
         }));
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(0x44332211ull));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
@@ -245,26 +249,26 @@ TEST_F(TimerPersistanceTest, TestStateWrite)
 
 TEST_F(TimerPersistanceTest, TestStateWriteClosesFiles)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
-    EXPECT_CALL(fs, Open(HasSubstr(".0"), _, _)).Times(3).WillRepeatedly(Return(1));
-    EXPECT_CALL(fs, Open(HasSubstr(".1"), _, _)).Times(3).WillRepeatedly(Return(2));
-    EXPECT_CALL(fs, Open(HasSubstr(".2"), _, _)).Times(3).WillRepeatedly(Return(3));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
+    EXPECT_CALL(fs, Open(HasSubstr(".0"), _, _)).Times(3).WillRepeatedly(Return(MakeOpenedFile(1)));
+    EXPECT_CALL(fs, Open(HasSubstr(".1"), _, _)).Times(3).WillRepeatedly(Return(MakeOpenedFile(2)));
+    EXPECT_CALL(fs, Open(HasSubstr(".2"), _, _)).Times(3).WillRepeatedly(Return(MakeOpenedFile(3)));
     EXPECT_CALL(fs, Close(1)).Times(3);
     EXPECT_CALL(fs, Close(2)).Times(3);
     EXPECT_CALL(fs, Close(3)).Times(3);
-    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(-1));
+    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultInvalidOperation)));
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(0x44332211ull));
     ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWriteIsNotDoneOnEveryTimeUpdate)
 {
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(-1));
-    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &MockedFileSystem));
-    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(1));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResultNotFound)));
+    EXPECT_TRUE(TimeInitialize(&provider, TimePassedProxy, nullptr, &fs));
+    EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
     EXPECT_CALL(fs, Close(_)).Times(9);
-    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(-1));
+    EXPECT_CALL(fs, Write(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultInvalidOperation)));
 
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(400000));
     TimeAdvanceTime(&provider, TimeSpanFromMilliseconds(100000));

--- a/unit_tests/time/persistance.cpp
+++ b/unit_tests/time/persistance.cpp
@@ -43,7 +43,6 @@ TimerPersistanceTest::TimerPersistanceTest()
     EXPECT_CALL(os, CreateBinarySemaphore()).WillOnce(Return(reinterpret_cast<void*>(1))).WillOnce(Return(reinterpret_cast<void*>(2)));
     ON_CALL(os, TakeSemaphore(_, _)).WillByDefault(Return(OSResultSuccess));
     ON_CALL(os, GiveSemaphore(_)).WillByDefault(Return(OSResultSuccess));
-    ON_CALL(fs, GetLastError()).WillByDefault(Return(0));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingStateNoState)
@@ -152,7 +151,7 @@ TEST_F(TimerPersistanceTest, TestReadingFilesGetClosed)
         .WillOnce(Return(MakeOpenedFile(1)))
         .WillOnce(Return(MakeOpenedFile(2)))
         .WillOnce(Return(MakeOpenedFile(3)));
-    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultOutOfResources)));
+    EXPECT_CALL(fs, Read(_, _, _)).WillRepeatedly(Return(MakeFSIOResult(OSResultNotEnoughMemory)));
     EXPECT_CALL(fs, Close(1)).Times(1);
     EXPECT_CALL(fs, Close(2)).Times(1);
     EXPECT_CALL(fs, Close(3)).Times(1);


### PR DESCRIPTION
* From now on all file system procedures receive pointer to FileSystem object as their first parameter to facilitate building abstraction layer over file system driver and allow much easier file system mocking,
* Separate operation status from context information returned by the
 * open,
 * read,
 * write
 * openDirectory
 procedures. From now on they returned dedicated types with separatied operation status (OSResult) and context information (i.e. fileHandle, number of bytes transfered) instead of pure ints,
* Migrate from pure int return values to OSResults,
* Map most of the errno error codes to OSResult enumerator,
* Update interface of open file procedure to:
 * separate file access mode (r, w, rw), from file opening mode,
 * drop the mode parameter that was supposed to be hard coded and will most likely never be changed.
 * introduce explicit enumerators for file access mode & file opening modes
* Update FsMock to support new file system interface.
* Fix doxygen issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/35)
<!-- Reviewable:end -->
