### PR TITLE
Comm get exact number of bytes from frame

### DIFF
--- a/libs/base/CMakeLists.txt
+++ b/libs/base/CMakeLists.txt
@@ -14,6 +14,10 @@ set(SOURCES
 
 add_library(${NAME} STATIC ${SOURCES})
 
+target_link_libraries(${NAME}
+    gsl
+)
+
 target_include_directories(${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Include)
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Include/base)
 target_format_sources(${NAME} "${SOURCES}")

--- a/libs/base/Include/base/reader.h
+++ b/libs/base/Include/base/reader.h
@@ -1,12 +1,10 @@
 #ifndef LIBS_BASE_READER_H
 #define LIBS_BASE_READER_H
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include "system.h"
+#pragma once
 
-EXTERNC_BEGIN
+#include <cstdint>
+#include "gsl/span"
 
 /**
  * @defgroup utilities General Purpose Utilities
@@ -20,17 +18,107 @@ EXTERNC_BEGIN
  * that is independent of both current memory layout and the actual
  * buffer location in memory.
  */
-typedef struct
+class Reader final
 {
+  public:
     /**
-     * @brief Pointer to the buffer in memory.
+     * @brief Default ctor.
      */
-    const uint8_t* buffer;
+    Reader();
 
     /**
-     * @brief Buffer length in bytes.
+     * @brief ctor.
+     * @param[in] view Window into memory buffer from which the data is read.
      */
-    uint16_t length;
+    Reader(gsl::span<const uint8_t> view);
+
+    /**
+     * @brief Initializes generic buffer reader.
+     *
+     * @param[in] view Window into memory buffer from which the data is read.
+     */
+    void Initialize(gsl::span<const uint8_t> view);
+
+    /**
+     * @brief Jumps over the requested amount of bytes.
+     * @param[in] length Number of bytes to skip.
+     * @return Operation status.
+     * @retval true Buffer is valid and there is still some unread data left in it.
+     * @retval false An attempt to read beyond the buffer end has been made.
+     */
+    bool Skip(uint16_t length);
+
+    /**
+     * @brief Returns current reader status.
+     * @retval true Buffer is valid and there is still some unread data left in it.
+     * @retval false An attempt to read beyond the buffer end has been made.
+     */
+    bool Status() const;
+
+    /**
+     * @brief Returns the number of not yet read bytes from the buffer.
+     * @retval true Buffer is valid and there is still some unread data left in it.
+     * @retval false An attempt to read beyond the buffer end has been made.
+     */
+    int32_t RemainingSize();
+
+    /**
+     * @brief Read single byte from the buffer and move the current position to the next byte.
+     * @return Read byte.
+     */
+    uint8_t ReadByte();
+
+    /**
+     * @brief Read single 16 bit word with little-endian memory orientation from the buffer
+     * and advance the current buffer position to the next unread byte.
+     * @return Read word.
+     */
+    uint16_t ReadWordLE();
+
+    /**
+     * @brief Read single 16 bit word with big-endian memory orientation from the buffer
+     * and advance the current buffer position to the next unread byte.
+     * @return Read word.
+     */
+    uint16_t ReadWordBE();
+
+    /**
+     * @brief Read single 32 bit word with little-endian memory orientation from the buffer
+     * and advance the current buffer position to the next unread byte.
+     * @return Read double word.
+     */
+    uint32_t ReadDoubleWordLE();
+
+    /**
+     * @brief Read single 64 bit word with little-endian memory orientation from the buffer
+     * and advance the current buffer position to the next unread byte.
+     * @return Read double word.
+     */
+    uint64_t ReadQuadWordLE();
+
+    /**
+     * @brief Read the requested number of bytes from the buffer.
+     *
+     * This method does not perform any operation/transformation on the data it only ensures that
+     * there are requested number of bytes available in the buffer and advances the current
+     * buffer position to the first byte beyond the requested block.
+     * @param[in] length Size in bytes of the requested data block.
+     * @return Pointer to the first byte of the requested memory block.
+     */
+    gsl::span<const uint8_t> ReadArray(uint16_t length);
+
+    /**
+     * @brief Resets reader to the initial state.
+     */
+    void Reset();
+
+  private:
+    bool UpdateState(uint16_t requestedSize);
+
+    /**
+     * @brief Window into memory buffer from which the data is read.
+     */
+    gsl::span<const uint8_t> buffer;
 
     /**
      * @brief Current buffer location.
@@ -46,102 +134,19 @@ typedef struct
      *  - False -> Buffer overflow detected.
      */
     bool isValid;
-} Reader;
+};
 
-/**
- * @brief Initializes generic buffer reader.
- *
- * @param[in] reader Pointer to reader object that should be initialized.
- * @param[in] buffer Buffer that should be read from.
- * @param[in] length The size in bytes of the data stored in the buffer.
- */
-void ReaderInitialize(Reader* reader, const uint8_t* buffer, uint16_t length);
-
-/**
- * @brief Returns current reader status.
- * @param[in] reader Pointer to the queried reader object.
- * @retval true Buffer is valid and there is still some unread data left in it.
- * @retval false An attempt to read beyond the buffer end has been made.
- */
-static bool ReaderStatus(const Reader* reader);
-
-/**
- * @brief Returns the number of not yet read bytes from the buffer.
- * @param[in] reader Pointer to the queried reader object.
- * @retval true Buffer is valid and there is still some unread data left in it.
- * @retval false An attempt to read beyond the buffer end has been made.
- */
-int32_t ReaderRemainingSize(const Reader* reader);
-
-/**
- * @brief Read single byte from the buffer and move the current position to the next byte.
- * @param[in] reader Pointer to the queried reader object.
- * @return Read byte.
- */
-uint8_t ReaderReadByte(Reader* reader);
-
-/**
- * @brief Read single 16 bit word with little-endian memory orientation from the buffer
- * and advance the current buffer position to the next unread byte.
- * @param[in] reader Pointer to the queried reader object.
- * @return Read word.
- */
-uint16_t ReaderReadWordLE(Reader* reader);
-
-/**
- * @brief Read single 16 bit word with big-endian memory orientation from the buffer
- * and advance the current buffer position to the next unread byte.
- * @param[in] reader Pointer to the queried reader object.
- * @return Read word.
- */
-uint16_t ReaderReadWordBE(Reader* reader);
-
-/**
- * @brief Read single 32 bit word with little-endian memory orientation from the buffer
- * and advance the current buffer position to the next unread byte.
- * @param[in] reader Pointer to the queried reader object.
- * @return Read double word.
- */
-uint32_t ReaderReadDoubleWordLE(Reader* reader);
-
-/**
- * @brief Read single 64 bit word with little-endian memory orientation from the buffer
- * and advance the current buffer position to the next unread byte.
- * @param[in] reader Pointer to the queried reader object.
- * @return Read double word.
- */
-uint64_t ReaderReadQuadWordLE(Reader* reader);
-
-/**
- * @brief Read the requested number of bytes from the buffer.
- *
- * This method does not perform any operation/transformation on the data it only ensures that
- * there are requested number of bytes available in the buffer and advances the current
- * buffer position to the first byte beyond the requested block.
- * @param[in] reader Pointer to the queried reader object.
- * @param[in] length Size in bytes of the requested data block.
- * @return Pointer to the first byte of the requested memory block.
- */
-const uint8_t* ReaderReadArray(Reader* reader, uint16_t length);
-
-/**
- * @brief Resets reader to the initial state.
- * @param[in] reader Pointer to the reader that should be reset.
- */
-static void ReaderReset(Reader* reader);
-
-static inline bool ReaderStatus(const Reader* reader)
+inline bool Reader::Status() const
 {
-    return reader->isValid;
+    return this->isValid;
 }
 
-static inline void ReaderReset(Reader* reader)
+inline void Reader::Reset()
 {
-    reader->position = 0;
-    reader->isValid = reader->buffer != NULL && reader->length > 0;
+    this->position = 0;
+    this->isValid = !this->buffer.empty();
 }
 
 /** @}*/
-EXTERNC_END
 
 #endif

--- a/libs/drivers/antenna/miniport.cpp
+++ b/libs/drivers/antenna/miniport.cpp
@@ -196,9 +196,8 @@ static OSResult GetDeploymentStatus(AntennaMiniportDriver* miniport,
         return result;
     }
 
-    Reader reader;
-    ReaderInitialize(&reader, output, sizeof(output));
-    const uint16_t value = ReaderReadWordLE(&reader);
+    Reader reader(output);
+    const uint16_t value = reader.ReadWordLE();
     if ((value & 0x1000) != 0)
     {
         LOGF(LOG_LEVEL_WARNING,
@@ -273,9 +272,8 @@ static OSResult GetAntennaActivationTime(AntennaMiniportDriver* miniport,
         return OSResult::IOError;
     }
 
-    Reader reader;
-    ReaderInitialize(&reader, output, sizeof(output));
-    const uint16_t value = ReaderReadWordBE(&reader);
+    Reader reader(output);
+    const uint16_t value = reader.ReadWordBE();
     *span = TimeSpanFromMilliseconds(value * 50);
     return OSResult::Success;
 }
@@ -301,9 +299,8 @@ static OSResult GetTemperature(AntennaMiniportDriver* miniport,
         return OSResult::IOError;
     }
 
-    Reader reader;
-    ReaderInitialize(&reader, output, sizeof(output));
-    const uint16_t value = ReaderReadWordBE(&reader);
+    Reader reader(output);
+    const uint16_t value = reader.ReadWordBE();
     if ((value & 0xfc00) != 0)
     {
         LOGF(LOG_LEVEL_WARNING,

--- a/libs/drivers/comm/Include/comm/comm.h
+++ b/libs/drivers/comm/Include/comm/comm.h
@@ -46,31 +46,169 @@ namespace devices
         /**
          * @brief Maximum allowed single frame content length.
          */
-        constexpr std::uint8_t COMM_MAX_FRAME_CONTENTS_SIZE = 235u;
+        constexpr std::uint16_t CommMaxFrameSize = 235u;
+
+        /**
+         * @brief Maximum allowed single frame content length.
+         */
+        constexpr std::uint16_t ComPrefferedBufferSize = CommMaxFrameSize + 20;
 
         /**
          * @brief This type describes single received frame.
+         *
+         * The payload view may not contain entire frame size, it will contain as much of the frame content as
+         * it was possible to fit in the buffer used for frame retrieval.
          */
-        struct CommFrame
+        class CommFrame
         {
+          public:
             /**
-             * @brief Returns span of @ref Contents limited to real content size (not maximum frame length)
+             * @brief ctor.
+             */
+            CommFrame();
+
+            /**
+             * @brief ctor.
+             * @param[in] doppler Frame doppler frequency.
+             * @param[in] rssi Received Signal Strength Indicator (RSSI) at the frame reception time.
+             * @param[in] fullSize Full frame size.
+             * @param[in] data span that contains entire received frame
+             */
+            CommFrame(std::uint16_t doppler, std::uint16_t rssi, std::uint16_t fullSize, gsl::span<std::uint8_t> data);
+
+            /**
+             * @brief Returns span that contains entire received frame.
              * @return Frame contents span
              */
-            gsl::span<const std::uint8_t> Payload();
+            const gsl::span<std::uint8_t>& Payload() const;
 
-            /** @brief Frame contents size in bytes. */
-            std::uint16_t Size;
+            /**
+             * @brief Returns Current frame size.
+             * @return Frame size in bytes.
+             */
+            std::uint16_t Size() const;
 
+            /**
+             * @brief Returns Actual frame size.
+             * @return Frame size in bytes.
+             */
+            std::uint16_t FullSize() const;
+
+            /**
+             * @brief Returns frame doppler frequency.
+             * @return Frame doppler frequency.
+             */
+            std::uint16_t Doppler() const;
+
+            /**
+             * @brief Return frame Received Signal Strength Indicator.
+             * @return Received Signal Strength Indicator.
+             */
+            std::uint16_t Rssi() const;
+
+            /**
+             * @brief Verifies value of the doppler frequency for this frame.
+             * @return Verification status.
+             * @retval true Doppler frequency is valid.
+             * @retval false Doppler frequency is invalid.
+             */
+            bool IsDopplerValid() const;
+
+            /**
+             * @brief Verifies value of the rssi for this frame.
+             * @return Verification status.
+             * @retval true Rssi is valid.
+             * @retval false Rssi is invalid.
+             */
+            bool IsRssiValid() const;
+
+            /**
+             * @brief Verifies size of this frame.
+             * @return Verification status.
+             * @retval true Frame size is valid.
+             * @retval false Frame size is invalid.
+             */
+            bool IsSizeValid() const;
+
+            /**
+             * @brief Verifies whether the entire frame content is represented by this object.
+             * @return Verification status.
+             * @retval true Entire frame is available.
+             * @retval false At least one payload byte is missing.
+             */
+            bool IsComplete() const;
+
+            /**
+             * @brief Verifies state of this frame object.
+             * @return Verification status.
+             * @retval true There are no errors and entire frame payload is available.
+             * @retval false There are errors or there is at least one byte missing.
+             */
+            bool Verify() const;
+
+          private:
             /** @brief Doppler frequency. This field contains the measured Doppler shift on the packet at the reception time. */
-            std::uint16_t Doppler;
+            std::uint16_t doppler;
 
             /** @brief This field contains the measured Received Signal Strength Indicator (RSSI) at the reception time. */
-            std::uint16_t RSSI;
+            std::uint16_t rssi;
+
+            /** @brief Complete size of the current frame. */
+            std::uint16_t fullFrameSize;
 
             /** @brief Frame content. */
-            std::array<uint8_t, COMM_MAX_FRAME_CONTENTS_SIZE> Contents;
+            gsl::span<std::uint8_t> content;
         };
+
+        inline const gsl::span<uint8_t>& CommFrame::Payload() const
+        {
+            return this->content;
+        }
+
+        inline std::uint16_t CommFrame::Size() const
+        {
+            return gsl::narrow_cast<std::uint16_t>(this->content.size());
+        }
+
+        inline std::uint16_t CommFrame::FullSize() const
+        {
+            return this->fullFrameSize;
+        }
+
+        inline std::uint16_t CommFrame::Doppler() const
+        {
+            return this->doppler;
+        }
+
+        inline std::uint16_t CommFrame::Rssi() const
+        {
+            return this->rssi;
+        }
+
+        inline bool CommFrame::IsDopplerValid() const
+        {
+            return (this->doppler & 0xf000) == 0;
+        }
+
+        inline bool CommFrame::IsRssiValid() const
+        {
+            return (this->rssi & 0xf000) == 0;
+        }
+
+        inline bool CommFrame::IsSizeValid() const
+        {
+            return this->fullFrameSize <= CommMaxFrameSize;
+        }
+
+        inline bool CommFrame::IsComplete() const
+        {
+            return this->fullFrameSize == gsl::narrow_cast<std::uint16_t>(this->content.size());
+        }
+
+        inline bool CommFrame::Verify() const
+        {
+            return IsDopplerValid() && IsRssiValid() && IsSizeValid() && IsComplete();
+        }
 
         /**
          * @brief This type contains comm receiver telemetry.
@@ -141,7 +279,7 @@ namespace devices
             std::uint8_t DataSize;
 
             /** @brief Beacon frame contents. */
-            std::uint8_t Data[COMM_MAX_FRAME_CONTENTS_SIZE];
+            std::uint8_t Data[CommMaxFrameSize];
         };
 
         /**
@@ -328,13 +466,16 @@ namespace devices
             /**
              * @brief Requests the contents of the oldest received frame from the queue.
              *
+             * @param[in] buffer Memory buffer that should be used for frame data retrieval.
              * @param[out] frame Reference to object that should be filled with the data describing the oldest
              * available received frame.
              * @return Operation status, true in case of success, false otherwise.
              *
              * The contents of the frame object is undefined in case of the failure.
+             * If the buffer too short to fit entire frame and it header only the part of the frame that will
+             * fit into this frame will be retrieved, parsed and returned back to the called.
              */
-            bool ReceiveFrame(CommFrame& frame);
+            bool ReceiveFrame(gsl::span<std::uint8_t> buffer, CommFrame& frame);
 
             /**
              * @brief This procedure sets the beacon frame for the passed comm object.

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -22,6 +22,18 @@ using drivers::i2c::I2CResult;
 
 using namespace devices::comm;
 
+CommFrame::CommFrame() : doppler(0), rssi(0)
+{
+}
+
+CommFrame::CommFrame(std::uint16_t dopplerLevel, std::uint16_t rssiLevel, std::uint16_t fullSize, gsl::span<std::uint8_t> data)
+    : doppler(dopplerLevel),   //
+      rssi(rssiLevel),         //
+      fullFrameSize(fullSize), //
+      content(std::move(data))
+{
+}
+
 CommObject::CommObject(II2CBus& low, IHandleFrame& upperInterface)
     : _low(low), //
       _frameHandler(upperInterface)
@@ -231,64 +243,76 @@ bool CommObject::GetTransmitterTelemetry(CommTransmitterTelemetry& telemetry)
     return reader.Status();
 }
 
-bool CommObject::ReceiveFrame(CommFrame& frame)
+static gsl::span<std::uint8_t> ReceiveSpan(std::uint16_t frameSize, gsl::span<std::uint8_t> buffer)
 {
-    uint8_t buffer[COMM_MAX_FRAME_CONTENTS_SIZE + 20];
-    bool status = this->SendCommandWithResponse(CommReceiver, ReceiverGetFrame, span<uint8_t>(buffer));
+    if (buffer.size() <= frameSize + 6)
+    {
+        return buffer;
+    }
+    else
+    {
+        return buffer.subspan(0, frameSize + 6);
+    }
+}
+
+bool CommObject::ReceiveFrame(gsl::span<std::uint8_t> buffer, CommFrame& frame)
+{
+    if (buffer.size() < 2)
+    {
+        return false;
+    }
+
+    bool status = this->SendCommandWithResponse(CommReceiver, ReceiverGetFrame, buffer.subspan(0, 2));
     if (!status)
     {
         return status;
     }
 
-    Reader reader(buffer);
-    frame.Size = reader.ReadWordLE();
-    frame.Doppler = reader.ReadWordLE();
-    frame.RSSI = reader.ReadWordLE();
-    const auto data = reader.ReadArray(frame.Size);
-
-    if (frame.Size > COMM_MAX_FRAME_CONTENTS_SIZE)
-    {
-        LOGF(LOG_LEVEL_ERROR, "[comm] Invalid frame length: %d", static_cast<int>(frame.Size));
-        return false;
-    }
-
-    if (!data.empty())
-    {
-        memcpy(frame.Contents.data(), data.data(), data.size());
-    }
-
-    status = reader.Status();
+    Reader reader(buffer.subspan(0, 2));
+    auto size = reader.ReadWordLE();
+    buffer = ReceiveSpan(size, buffer);
+    status = this->SendCommandWithResponse(CommReceiver, ReceiverGetFrame, buffer);
     if (!status)
+    {
+        return status;
+    }
+
+    reader.Initialize(buffer);
+    const auto fullSize = reader.ReadWordLE();
+    const auto doppler = reader.ReadWordLE();
+    const auto rssi = reader.ReadWordLE();
+    gsl::span<std::uint8_t> frameContent;
+    if (!reader.Status())
     {
         LOG(LOG_LEVEL_ERROR, "[comm] Failed to receive frame");
     }
     else
     {
-        LOGF(LOG_LEVEL_DEBUG, "[comm] Received frame %d bytes", static_cast<int>(frame.Size));
+        LOGF(LOG_LEVEL_DEBUG, "[comm] Received frame %d bytes", static_cast<int>(fullSize));
+        auto span = reader.ReadArray(reader.RemainingSize());
+        frameContent = gsl::span<std::uint8_t>(const_cast<std::uint8_t*>(span.data()), span.size());
     }
 
-    if (frame.Size == 0 || (frame.Doppler & 0xf000) != 0 || (frame.RSSI & 0xf000) != 0)
-    {
-        LOGF(LOG_LEVEL_ERROR,                                                       //
-            "[comm] Received invalid frame. Size: %d, Doppler: 0x%X, RSSI: 0x%X. ", //
-            frame.Size,                                                             //
-            frame.Doppler,                                                          //
-            frame.RSSI);
-        return false;
-    }
+    frame = CommFrame(doppler, rssi, fullSize, std::move(frameContent));
+
+    //    if (fullSize == 0 || (doppler & 0xf000) != 0 || (rssi & 0xf000) != 0)
+    //    {
+    //        LOGF(LOG_LEVEL_ERROR, "[comm] Received invalid frame. Size: %d, Doppler: 0x%X, RSSI: 0x%X. ", fullSize, doppler, rssi);
+    //        return false;
+    //    }
 
     return status;
 }
 
 bool CommObject::SendFrame(span<const std::uint8_t> frame)
 {
-    if (frame.size() > COMM_MAX_FRAME_CONTENTS_SIZE)
+    if (frame.size() > CommMaxFrameSize)
     {
-        LOGF(LOG_LEVEL_ERROR, "Frame payload is too long. Allowed: %d, Requested: '%d'.", COMM_MAX_FRAME_CONTENTS_SIZE, frame.size());
+        LOGF(LOG_LEVEL_ERROR, "Frame payload is too long. Allowed: %d, Requested: '%d'.", CommMaxFrameSize, frame.size());
         return false;
     }
 
-    uint8_t cmd[255];
+    uint8_t cmd[ComPrefferedBufferSize];
     cmd[0] = TransmitterSendFrame;
     memcpy(cmd + 1, frame.data(), frame.size());
     uint8_t remainingBufferSize;
@@ -312,7 +336,7 @@ bool CommObject::SendFrame(span<const std::uint8_t> frame)
 
 bool CommObject::SetBeacon(const CommBeacon& beaconData)
 {
-    uint8_t buffer[COMM_MAX_FRAME_CONTENTS_SIZE + 2];
+    uint8_t buffer[CommMaxFrameSize + 2];
     Writer writer;
     WriterInitialize(&writer, buffer, COUNT_OF(buffer));
     WriterWriteByte(&writer, TransmitterSetBeacon);
@@ -383,12 +407,13 @@ void CommObject::PollHardware()
     }
     else if (frameResponse.frameCount > 0)
     {
+        std::uint8_t buffer[ComPrefferedBufferSize];
         LOGF(LOG_LEVEL_INFO, "[comm] Got %d frames", frameResponse.frameCount);
 
         for (uint8_t i = 0; i < frameResponse.frameCount; i++)
         {
             CommFrame frame;
-            bool status = this->ReceiveFrame(frame);
+            bool status = this->ReceiveFrame(buffer, frame);
             if (!status)
             {
                 LOG(LOG_LEVEL_ERROR, "[comm] Unable to receive frame. ");
@@ -400,7 +425,7 @@ void CommObject::PollHardware()
                     LOG(LOG_LEVEL_ERROR, "[comm] Unable to remove frame from receiver. ");
                 }
 
-                LOGF(LOG_LEVEL_INFO, "[comm] Received frame %d bytes. ", (int)frame.Size);
+                LOGF(LOG_LEVEL_INFO, "[comm] Received frame %d bytes. ", static_cast<int>(frame.Size()));
                 this->_frameHandler.HandleFrame(*this, frame);
             }
         }
@@ -425,9 +450,4 @@ void CommObject::CommTask(void* param)
             comm->PollHardware();
         }
     }
-}
-
-span<const uint8_t> CommFrame::Payload()
-{
-    return span<const uint8_t>(this->Contents.begin(), this->Size);
 }

--- a/libs/time/timer.cpp
+++ b/libs/time/timer.cpp
@@ -272,10 +272,9 @@ static struct TimeSnapshot ReadFile(FileSystem* fs, const char* const filePath)
         return result;
     }
 
-    Reader reader;
-    ReaderInitialize(&reader, buffer, sizeof(buffer));
-    result.CurrentTime.value = ReaderReadQuadWordLE(&reader);
-    if (!ReaderStatus(&reader))
+    Reader reader(buffer);
+    result.CurrentTime.value = reader.ReadQuadWordLE();
+    if (!reader.Status())
     {
         LOGF(LOG_LEVEL_WARNING, "Not enough data read from file: %s. ", filePath);
         return result;

--- a/src/commands/comm.cpp
+++ b/src/commands/comm.cpp
@@ -41,7 +41,8 @@ void ReceiveFrameHandler(uint16_t argc, char* argv[])
     UNREFERENCED_PARAMETER(argv);
     LOG(LOG_LEVEL_INFO, "Received request to get the oldes frame from comm...");
     CommFrame frame;
-    if (!Main.Communication.CommDriver.ReceiveFrame(frame))
+    std::uint8_t buffer[devices::comm::ComPrefferedBufferSize];
+    if (!Main.Communication.CommDriver.ReceiveFrame(buffer, frame))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to get frame from comm. ");
     }
@@ -50,9 +51,8 @@ void ReceiveFrameHandler(uint16_t argc, char* argv[])
         Main.Communication.CommDriver.RemoveFrame();
 
         auto payload = frame.Payload();
-        auto payloadStr = reinterpret_cast<const char*>(&payload[0]);
-
-        Main.terminal.PrintBuffer(gsl::span<const char>(payloadStr, frame.Size));
+        auto payloadStr = reinterpret_cast<const char*>(payload.data());
+        Main.terminal.PrintBuffer(gsl::span<const char>(payloadStr, payload.size()));
     }
 }
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
   FileSystem/MemoryDriver.cpp
   FileSystem/EccTest.cpp
   Comm/CommTest.cpp
+  Comm/CommFrameTest.cpp
   TeleCommandHandling/TeleCommandHandlingTest.cpp
   base/ReaderTest.cpp
   base/WriterTest.cpp

--- a/unit_tests/Comm/CommFrameTest.cpp
+++ b/unit_tests/Comm/CommFrameTest.cpp
@@ -1,0 +1,83 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock-matchers.h"
+#include "comm/comm.h"
+
+using namespace devices::comm;
+
+using testing::Eq;
+
+TEST(CommFrameTest, TestEmptyFrame)
+{
+    CommFrame frame;
+    ASSERT_THAT(frame.Size(), Eq(0));
+    ASSERT_THAT(frame.FullSize(), Eq(0));
+    ASSERT_THAT(frame.Rssi(), Eq(0));
+    ASSERT_THAT(frame.Doppler(), Eq(0));
+    ASSERT_THAT(frame.Payload().empty(), Eq(true));
+}
+
+TEST(CommFrameTest, TestSimpleFrame)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(1, 2, 10, buffer);
+    ASSERT_THAT(frame.Size(), Eq(10));
+    ASSERT_THAT(frame.FullSize(), Eq(10));
+    ASSERT_THAT(frame.Rssi(), Eq(2));
+    ASSERT_THAT(frame.Doppler(), Eq(1));
+    ASSERT_THAT(frame.IsComplete(), Eq(true));
+    ASSERT_THAT(frame.Payload().empty(), Eq(false));
+    ASSERT_THAT(frame.Payload().data(), Eq(buffer));
+}
+
+TEST(CommFrameTest, TestSimpleEmptyFrame)
+{
+    CommFrame frame(1, 2, 0, gsl::span<std::uint8_t>());
+    ASSERT_THAT(frame.Size(), Eq(0));
+    ASSERT_THAT(frame.FullSize(), Eq(0));
+    ASSERT_THAT(frame.Payload().empty(), Eq(true));
+}
+
+TEST(CommFrameTest, TestSimpleFrameRssiVerification)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(1, 0xfff, 10, buffer);
+    ASSERT_THAT(frame.IsRssiValid(), Eq(true));
+    ASSERT_THAT(frame.Verify(), Eq(true));
+}
+
+TEST(CommFrameTest, TestSimpleFrameRssiVerificationFailure)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(1, 0xf000, 10, buffer);
+    ASSERT_THAT(frame.IsRssiValid(), Eq(false));
+    ASSERT_THAT(frame.Verify(), Eq(false));
+}
+
+TEST(CommFrameTest, TestSimpleFrameDoppleVerification)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(0xfff, 1, 10, buffer);
+    ASSERT_THAT(frame.IsDopplerValid(), Eq(true));
+    ASSERT_THAT(frame.Verify(), Eq(true));
+}
+
+TEST(CommFrameTest, TestSimpleFrameDopplerVerificationFailure)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(0xf000, 1, 10, buffer);
+    ASSERT_THAT(frame.IsDopplerValid(), Eq(false));
+    ASSERT_THAT(frame.Verify(), Eq(false));
+}
+
+TEST(CommFrameTest, TestPartialFrame)
+{
+    std::uint8_t buffer[10];
+    CommFrame frame(0xf000, 1, 16, buffer);
+    ASSERT_THAT(frame.Size(), Eq(10));
+    ASSERT_THAT(frame.FullSize(), Eq(16));
+    ASSERT_THAT(frame.Payload().empty(), Eq(false));
+    ASSERT_THAT(frame.Payload().data(), Eq(buffer));
+    ASSERT_THAT(frame.Payload().size(), Eq(10));
+    ASSERT_THAT(frame.IsComplete(), Eq(false));
+    ASSERT_THAT(frame.Verify(), Eq(false));
+}

--- a/unit_tests/base/ReaderTest.cpp
+++ b/unit_tests/base/ReaderTest.cpp
@@ -5,19 +5,35 @@
 
 using testing::Eq;
 
-TEST(ReaderTest, TestStatusNullBuffer)
+TEST(ReaderTest, TestDefaultCtor)
 {
     Reader reader;
-    ReaderInitialize(&reader, NULL, 1);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    ASSERT_FALSE(reader.Status());
+    ASSERT_THAT(reader.RemainingSize(), Eq(0));
+}
+
+TEST(ReaderTest, TestStatusNullBuffer)
+{
+    gsl::span<const std::uint8_t> span;
+    Reader reader(span);
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestStatusZeroSizeBuffer)
 {
     uint8_t array[1];
     Reader reader;
-    ReaderInitialize(&reader, array, 0);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(gsl::span<const std::uint8_t>(array, 0));
+    ASSERT_FALSE(reader.Status());
+}
+
+TEST(ReaderTest, TestCtorStatusValidBuffer)
+{
+    uint8_t array[] = {0x55, 0xaa};
+
+    Reader reader(array);
+    ASSERT_TRUE(reader.Status());
+    ASSERT_THAT(reader.RemainingSize(), Eq(2));
 }
 
 TEST(ReaderTest, TestStatusValidBuffer)
@@ -25,8 +41,8 @@ TEST(ReaderTest, TestStatusValidBuffer)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingSingleByte)
@@ -34,9 +50,35 @@ TEST(ReaderTest, TestReadingSingleByte)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadByte(&reader), Eq(0x55));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadByte(), Eq(0x55));
+    ASSERT_TRUE(reader.Status());
+}
+
+TEST(ReaderTest, TestSkip)
+{
+    uint8_t array[] = {0x55, 0xaa};
+    Reader reader(array);
+    ASSERT_THAT(reader.Skip(1), Eq(true));
+    ASSERT_TRUE(reader.Status());
+    ASSERT_THAT(reader.RemainingSize(), Eq(1));
+}
+
+TEST(ReaderTest, TestSkipOverTheLimit)
+{
+    uint8_t array[] = {0x55, 0xaa};
+    Reader reader(array);
+    ASSERT_THAT(reader.Skip(3), Eq(false));
+    ASSERT_FALSE(reader.Status());
+}
+
+TEST(ReaderTest, TestSkipToTheLimit)
+{
+    uint8_t array[] = {0x55, 0xaa};
+    Reader reader(array);
+    ASSERT_THAT(reader.Skip(2), Eq(true));
+    ASSERT_TRUE(reader.Status());
+    ASSERT_THAT(reader.RemainingSize(), Eq(0));
 }
 
 TEST(ReaderTest, TestReadingSingleByteBeyondEnd)
@@ -44,10 +86,10 @@ TEST(ReaderTest, TestReadingSingleByteBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadByte(&reader);
-    ReaderReadByte(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadByte();
+    reader.ReadByte();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingWordLE)
@@ -55,9 +97,9 @@ TEST(ReaderTest, TestReadingWordLE)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadWordLE(&reader), Eq(0xaa55));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadWordLE(), Eq(0xaa55));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingWordBE)
@@ -65,9 +107,9 @@ TEST(ReaderTest, TestReadingWordBE)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadWordBE(&reader), Eq(0x55aa));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadWordBE(), Eq(0x55aa));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingWordLEBeyondEnd)
@@ -75,9 +117,9 @@ TEST(ReaderTest, TestReadingWordLEBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadWordLE(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadWordLE();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingWordBEBeyondEnd)
@@ -85,9 +127,9 @@ TEST(ReaderTest, TestReadingWordBEBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadWordBE(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadWordBE();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingDWordLE)
@@ -95,9 +137,9 @@ TEST(ReaderTest, TestReadingDWordLE)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadDoubleWordLE(&reader), Eq(0xEE77AA55U));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadDoubleWordLE(), Eq(0xEE77AA55U));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingQuadWordLE)
@@ -105,9 +147,9 @@ TEST(ReaderTest, TestReadingQuadWordLE)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee, 0x66, 0xcc, 0x44, 0x88};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadQuadWordLE(&reader), Eq(0x8844CC66EE77AA55ULL));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadQuadWordLE(), Eq(0x8844CC66EE77AA55ULL));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingQuadLEBeyondEnd)
@@ -115,9 +157,9 @@ TEST(ReaderTest, TestReadingQuadLEBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee, 0x66, 0xcc, 0x44};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadQuadWordLE(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadQuadWordLE();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingDWordLEBeyondEnd)
@@ -125,19 +167,19 @@ TEST(ReaderTest, TestReadingDWordLEBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadDoubleWordLE(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadDoubleWordLE();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadArray)
 {
     Reader reader;
-    uint8_t array[] = {0x55, 0xaa, 0x77};
+    const uint8_t array[] = {0x55, 0xaa, 0x77};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadArray(&reader, 3), Eq(array));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadArray(3), Eq(gsl::make_span(array)));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadArrayBeyondEnd)
@@ -145,9 +187,9 @@ TEST(ReaderTest, TestReadArrayBeyondEnd)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadArray(&reader, 4), Eq(nullptr));
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadArray(4).empty(), Eq(true));
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingMovesPosition)
@@ -155,14 +197,14 @@ TEST(ReaderTest, TestReadingMovesPosition)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderReadByte(&reader), Eq(0x55));
-    ASSERT_THAT(ReaderReadWordLE(&reader), Eq(0x77AA));
-    ASSERT_THAT(ReaderReadDoubleWordLE(&reader), Eq(0x332211EEU));
-    ASSERT_THAT(ReaderReadArray(&reader, 3), Eq(&array[7]));
-    ASSERT_THAT(ReaderReadByte(&reader), Eq(0x77));
-    ASSERT_THAT(ReaderReadWordBE(&reader), Eq(0x8899));
-    ASSERT_TRUE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.ReadByte(), Eq(0x55));
+    ASSERT_THAT(reader.ReadWordLE(), Eq(0x77AA));
+    ASSERT_THAT(reader.ReadDoubleWordLE(), Eq(0x332211EEU));
+    ASSERT_THAT(reader.ReadArray(3), Eq(gsl::span<const std::uint8_t>(array + 7, 3)));
+    ASSERT_THAT(reader.ReadByte(), Eq(0x77));
+    ASSERT_THAT(reader.ReadWordBE(), Eq(0x8899));
+    ASSERT_TRUE(reader.Status());
 }
 
 TEST(ReaderTest, TestReadingWithInvalidState)
@@ -170,14 +212,14 @@ TEST(ReaderTest, TestReadingWithInvalidState)
     Reader reader;
     uint8_t array[] = {0x55};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadByte(&reader);
-    ReaderReadWordLE(&reader);
-    ReaderReadWordBE(&reader);
-    ReaderReadDoubleWordLE(&reader);
-    ReaderReadArray(&reader, 3);
-    ReaderReadByte(&reader);
-    ASSERT_FALSE(ReaderStatus(&reader));
+    reader.Initialize(array);
+    reader.ReadByte();
+    reader.ReadWordLE();
+    reader.ReadWordBE();
+    reader.ReadDoubleWordLE();
+    reader.ReadArray(3);
+    reader.ReadByte();
+    ASSERT_FALSE(reader.Status());
 }
 
 TEST(ReaderTest, TestRemainigSizeNoDataRead)
@@ -185,8 +227,8 @@ TEST(ReaderTest, TestRemainigSizeNoDataRead)
     Reader reader;
     uint8_t array[] = {0x55};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ASSERT_THAT(ReaderRemainingSize(&reader), Eq(1));
+    reader.Initialize(array);
+    ASSERT_THAT(reader.RemainingSize(), Eq(1));
 }
 
 TEST(ReaderTest, TestRemainigSize)
@@ -194,11 +236,11 @@ TEST(ReaderTest, TestRemainigSize)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadByte(&reader);
-    ReaderReadWordLE(&reader);
-    ReaderReadDoubleWordLE(&reader);
-    ASSERT_THAT(ReaderRemainingSize(&reader), Eq(static_cast<int32_t>(COUNT_OF(array) - 7)));
+    reader.Initialize(array);
+    reader.ReadByte();
+    reader.ReadWordLE();
+    reader.ReadDoubleWordLE();
+    ASSERT_THAT(reader.RemainingSize(), Eq(static_cast<int32_t>(COUNT_OF(array) - 7)));
 }
 
 TEST(ReaderTest, TestRemainigSizeAtTheEnd)
@@ -206,12 +248,12 @@ TEST(ReaderTest, TestRemainigSizeAtTheEnd)
     Reader reader;
     uint8_t array[] = {0x55, 0xaa, 0x77, 0xee, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
 
-    ReaderInitialize(&reader, array, sizeof(array));
-    ReaderReadByte(&reader);
-    ReaderReadWordLE(&reader);
-    ReaderReadDoubleWordLE(&reader);
-    ReaderReadArray(&reader, 3);
-    ReaderReadByte(&reader);
-    ReaderReadWordBE(&reader);
-    ASSERT_THAT(ReaderRemainingSize(&reader), Eq(0));
+    reader.Initialize(array);
+    reader.ReadByte();
+    reader.ReadWordLE();
+    reader.ReadDoubleWordLE();
+    reader.ReadArray(3);
+    reader.ReadByte();
+    reader.ReadWordBE();
+    ASSERT_THAT(reader.RemainingSize(), Eq(0));
 }


### PR DESCRIPTION
* Migrate buffer reader to c++ object, 
* Communication module update.
  * From now on the communication module will first query the frame for its size and then download from the hardware the necessary minimum number of bytes needed.
  * Update CommFrame interface to use the someone else's memory buffer instead of its own fixed size array.
  * Move the frame verification logic out of frame receive procedure to ensure that invalid frame content will block the frame receive path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/62)
<!-- Reviewable:end -->
