### PR TITLE
Replaced `TimeSpan with `std::chrono::duration`

### DIFF
--- a/libs/adcs/adcs.cpp
+++ b/libs/adcs/adcs.cpp
@@ -28,7 +28,7 @@ static void ADCSTask(void* arg)
     {
         ADCSCommand command;
 
-        if (System::QueueReceive(context->CommandQueue, &command, OSTaskTimeSpan(0)))
+        if (System::QueueReceive(context->CommandQueue, &command, std::chrono::milliseconds(0)))
         {
             LOGF(LOG_LEVEL_INFO, "[ADCS]Received command %d", command);
 
@@ -36,7 +36,7 @@ static void ADCSTask(void* arg)
         }
 
         LOGF(LOG_LEVEL_TRACE, "[ADCS]Running ADCS loop. Mode: %d", context->CurrentMode);
-        System::SleepTask(OSTaskTimeSpan(5000));
+        System::SleepTask(std::chrono::seconds(5));
     }
 }
 

--- a/libs/adcs/adcs.cpp
+++ b/libs/adcs/adcs.cpp
@@ -2,6 +2,8 @@
 #include "logger/logger.h"
 #include "system.h"
 
+using namespace std::chrono_literals;
+
 static void HandleCommand(ADCSContext* context, ADCSCommand command)
 {
     switch (command)
@@ -28,7 +30,7 @@ static void ADCSTask(void* arg)
     {
         ADCSCommand command;
 
-        if (System::QueueReceive(context->CommandQueue, &command, std::chrono::milliseconds(0)))
+        if (System::QueueReceive(context->CommandQueue, &command, 0ms))
         {
             LOGF(LOG_LEVEL_INFO, "[ADCS]Received command %d", command);
 
@@ -36,7 +38,7 @@ static void ADCSTask(void* arg)
         }
 
         LOGF(LOG_LEVEL_TRACE, "[ADCS]Running ADCS loop. Mode: %d", context->CurrentMode);
-        System::SleepTask(std::chrono::seconds(5));
+        System::SleepTask(5s);
     }
 }
 

--- a/libs/adcs/adcs.cpp
+++ b/libs/adcs/adcs.cpp
@@ -28,7 +28,7 @@ static void ADCSTask(void* arg)
     {
         ADCSCommand command;
 
-        if (System::QueueReceive(context->CommandQueue, &command, 0))
+        if (System::QueueReceive(context->CommandQueue, &command, OSTaskTimeSpan(0)))
         {
             LOGF(LOG_LEVEL_INFO, "[ADCS]Received command %d", command);
 
@@ -36,7 +36,7 @@ static void ADCSTask(void* arg)
         }
 
         LOGF(LOG_LEVEL_TRACE, "[ADCS]Running ADCS loop. Mode: %d", context->CurrentMode);
-        System::SleepTask(5000);
+        System::SleepTask(OSTaskTimeSpan(5000));
     }
 }
 

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -146,9 +146,6 @@ constexpr inline bool OS_RESULT_FAILED(OSResult x)
     return x != OSResult::Success;
 }
 
-/** @brief Type definition for time span in ms. */
-using OSTaskTimeSpan = std::chrono::milliseconds;
-
 /** @brief Type definition of handle to system task. */
 using OSTaskHandle = void*;
 
@@ -225,7 +222,7 @@ class System final : public PureStatic
      * @brief Suspends current task execution for specified time period.
      * @param[in] time Time period in ms.
      */
-    static void SleepTask(const OSTaskTimeSpan time);
+    static void SleepTask(const std::chrono::milliseconds time);
 
     /**
      * @brief Resumes execution of requested task.
@@ -262,7 +259,7 @@ class System final : public PureStatic
      * @return Operation status.
      * @remark This procedure should not be used from within interrupt service routine.
      */
-    static OSResult TakeSemaphore(OSSemaphoreHandle semaphore, OSTaskTimeSpan timeout);
+    static OSResult TakeSemaphore(OSSemaphoreHandle semaphore, std::chrono::milliseconds timeout);
 
     /**
      * @brief Releases semaphore.
@@ -343,8 +340,11 @@ class System final : public PureStatic
      * @return The value of the event group at the time either the event bits being waited for became set,
      * or the block time expired.
      */
-    static OSEventBits EventGroupWaitForBits(
-        OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const OSTaskTimeSpan timeout);
+    static OSEventBits EventGroupWaitForBits(OSEventGroupHandle eventGroup,
+        const OSEventBits bitsToWaitFor,
+        bool waitAll,
+        bool autoReset,
+        const std::chrono::milliseconds timeout);
 
     /**
      * @brief Allocates block of memory from OS heap
@@ -377,7 +377,7 @@ class System final : public PureStatic
      * @param[in] timeout Operation timeout in ms.
      * @return TRUE if element was received, FALSE on timeout
      */
-    static bool QueueReceive(OSQueueHandle queue, void* element, OSTaskTimeSpan timeout);
+    static bool QueueReceive(OSQueueHandle queue, void* element, std::chrono::milliseconds timeout);
 
     /**
      * @brief Receives element form queue in interrupt handler
@@ -396,7 +396,7 @@ class System final : public PureStatic
      * @param[in] timeout Operation timeout in ms
      * @return TRUE if element was received, FALSE on timeout
      */
-    static bool QueueSend(OSQueueHandle queue, const void* element, OSTaskTimeSpan timeout);
+    static bool QueueSend(OSQueueHandle queue, const void* element, std::chrono::milliseconds timeout);
 
     /**
      * @brief Sends element to queue in interrupt handler
@@ -434,7 +434,7 @@ class System final : public PureStatic
      * @param[in] timeout Operation timeout in ms
      * @return Wait result
      */
-    static OSResult PulseWait(OSPulseHandle handle, OSTaskTimeSpan timeout);
+    static OSResult PulseWait(OSPulseHandle handle, std::chrono::milliseconds timeout);
 
     /**
      * @brief Sets pulse event
@@ -450,7 +450,7 @@ class System final : public PureStatic
      * @brief Gets number of miliseconds since system start
      * @return Number of miliseconds since system start
      */
-    static OSTaskTimeSpan GetUptime();
+    static std::chrono::milliseconds GetUptime();
 };
 
 /**
@@ -544,7 +544,7 @@ class Lock final : private NotCopyable, private NotMoveable
      * @param[in] semaphore Semaphore to take
      * @param[in] timeout Timeout
      */
-    Lock(OSSemaphoreHandle semaphore, OSTaskTimeSpan timeout);
+    Lock(OSSemaphoreHandle semaphore, std::chrono::milliseconds timeout);
 
     /**
      * @brief Releases semaphore (if taken) on object destruction
@@ -584,7 +584,7 @@ template <typename Element, std::size_t Capacity> class Queue final
      * @param[in] timeout Timeout in ms
      * @return Operation result
      */
-    OSResult Push(const Element& element, OSTaskTimeSpan timeout);
+    OSResult Push(const Element& element, std::chrono::milliseconds timeout);
 
     /**
      * @brief Pushes element to queue from interrupt service routine
@@ -599,7 +599,7 @@ template <typename Element, std::size_t Capacity> class Queue final
      * @param[in] timeout Timeout in ms
      * @return Operation result
      */
-    OSResult Pop(Element& element, OSTaskTimeSpan timeout);
+    OSResult Pop(Element& element, std::chrono::milliseconds timeout);
 
   private:
     /** @brief Queue handle */
@@ -618,7 +618,8 @@ template <typename Element, std::size_t Capacity> OSResult Queue<Element, Capaci
     return OSResult::Success;
 }
 
-template <typename Element, std::size_t Capacity> OSResult Queue<Element, Capacity>::Push(const Element& element, OSTaskTimeSpan timeout)
+template <typename Element, std::size_t Capacity>
+OSResult Queue<Element, Capacity>::Push(const Element& element, std::chrono::milliseconds timeout)
 {
     if (System::QueueSend(this->_handle, &element, timeout))
     {
@@ -636,7 +637,8 @@ template <typename Element, std::size_t Capacity> OSResult Queue<Element, Capaci
     return OSResult::Overflow;
 }
 
-template <typename Element, std::size_t Capacity> OSResult Queue<Element, Capacity>::Pop(Element& element, OSTaskTimeSpan timeout)
+template <typename Element, std::size_t Capacity>
+OSResult Queue<Element, Capacity>::Pop(Element& element, std::chrono::milliseconds timeout)
 {
     if (System::QueueReceive(this->_handle, &element, timeout))
     {
@@ -669,7 +671,7 @@ class Timeout final
      * @brief Constructs new Timeout object
      * @param[in] timeout Timeout in miliseconds
      */
-    Timeout(OSTaskTimeSpan timeout);
+    Timeout(std::chrono::milliseconds timeout);
 
     /**
      * @brief Checks is timeout is expired
@@ -681,7 +683,7 @@ class Timeout final
     /**
      * @brief System uptime at which timeout will expire
      */
-    const OSTaskTimeSpan _expireAt;
+    const std::chrono::milliseconds _expireAt;
 };
 
 /** @}*/

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -147,7 +147,7 @@ constexpr inline bool OS_RESULT_FAILED(OSResult x)
 }
 
 /** @brief Type definition for time span in ms. */
-using OSTaskTimeSpan = std::chrono::duration<uint64_t, std::milli>;
+using OSTaskTimeSpan = std::chrono::milliseconds;
 
 /** @brief Type definition of handle to system task. */
 using OSTaskHandle = void*;

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <chrono>
 #include <cstdint>
 #include <type_traits>
 #include <utility>
@@ -146,7 +147,7 @@ constexpr inline bool OS_RESULT_FAILED(OSResult x)
 }
 
 /** @brief Type definition for time span in ms. */
-using OSTaskTimeSpan = std::uint32_t;
+using OSTaskTimeSpan = std::chrono::duration<uint64_t, std::milli>;
 
 /** @brief Type definition of handle to system task. */
 using OSTaskHandle = void*;

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -19,7 +19,8 @@
 /**
  * @brief Maximal allowed operation timeout.
  */
-#define MAX_DELAY 0xffffffffUL
+
+static constexpr std::chrono::milliseconds InfiniteTimeout = std::chrono::milliseconds::max();
 
 #ifndef ELAST
 // newlib workaround

--- a/libs/base/os_base.cpp
+++ b/libs/base/os_base.cpp
@@ -1,7 +1,7 @@
 
 #include "os.h"
 
-Lock::Lock(OSSemaphoreHandle semaphore, OSTaskTimeSpan timeout) : _semaphore(semaphore)
+Lock::Lock(OSSemaphoreHandle semaphore, std::chrono::milliseconds timeout) : _semaphore(semaphore)
 {
     this->_taken = OS_RESULT_SUCCEEDED(System::TakeSemaphore(this->_semaphore, timeout));
 }
@@ -19,7 +19,7 @@ bool Lock::operator()()
     return this->_taken;
 }
 
-Timeout::Timeout(OSTaskTimeSpan timeout) : _expireAt(System::GetUptime() + timeout)
+Timeout::Timeout(std::chrono::milliseconds timeout) : _expireAt(System::GetUptime() + timeout)
 {
 }
 

--- a/libs/base/os_base.cpp
+++ b/libs/base/os_base.cpp
@@ -19,7 +19,7 @@ bool Lock::operator()()
     return this->_taken;
 }
 
-Timeout::Timeout(std::uint32_t timeout) : _expireAt(System::GetUptime() + timeout)
+Timeout::Timeout(OSTaskTimeSpan timeout) : _expireAt(System::GetUptime() + timeout)
 {
 }
 

--- a/libs/drivers/antenna/Include/antenna/driver.h
+++ b/libs/drivers/antenna/Include/antenna/driver.h
@@ -137,7 +137,7 @@ struct AntennaTelemetry
      * Value at index 0 is valid only when ANT_TM_ANTENNA1_ACTIVATION_TIME bit is set in the flags field,
      * Value at index 1 is valid only when ANT_TM_ANTENNA2_ACTIVATION_TIME bit is set in the flags field and so on.
      */
-    TimeSpan ActivationTime[4];
+    std::chrono::milliseconds ActivationTime[4];
 
     /**
      * @brief Array that contains temperatures measured by both primary and backup channels.
@@ -234,7 +234,7 @@ struct AntennaDriver
     OSResult (*DeployAntenna)(struct AntennaDriver* driver,
         AntennaChannel channel,
         AntennaId antennaId,
-        TimeSpan timeout,
+        std::chrono::milliseconds timeout,
         bool overrideSwitches //
         );
 

--- a/libs/drivers/antenna/Include/antenna/miniport.h
+++ b/libs/drivers/antenna/Include/antenna/miniport.h
@@ -81,7 +81,7 @@ struct AntennaMiniportDriver
         drivers::i2c::II2CBus* communicationBus,
         AntennaChannel channel,
         AntennaId antennaId,
-        TimeSpan timeout,
+        std::chrono::milliseconds timeout,
         bool override //
         );
 
@@ -96,7 +96,7 @@ struct AntennaMiniportDriver
     OSResult (*InitializeAutomaticDeployment)(struct AntennaMiniportDriver* miniport,
         drivers::i2c::II2CBus* communicationBus,
         AntennaChannel channel,
-        TimeSpan timeout //
+        std::chrono::milliseconds timeout //
         );
 
     /**
@@ -162,7 +162,7 @@ struct AntennaMiniportDriver
         drivers::i2c::II2CBus* communicationBus,
         AntennaChannel channel,
         AntennaId antennaId,
-        TimeSpan* count //
+        std::chrono::milliseconds* count //
         );
 
     /**

--- a/libs/drivers/antenna/antenna.cpp
+++ b/libs/drivers/antenna/antenna.cpp
@@ -201,7 +201,9 @@ static void UpdateActivationTime(struct AntennaDriver* driver, AntennaTelemetry*
     AntennaChannelInfo* backupChannel = GetChannel(driver, ANTENNA_BACKUP_CHANNEL);
     for (int i = 0; i < 4; ++i)
     {
-        TimeSpan primaryValue = {0}, secondaryValue = {0};
+        TimeSpan primaryValue(0);
+        TimeSpan secondaryValue(0);
+
         const OSResult primary = driver->miniport->GetAntennaActivationTime(driver->miniport,
             primaryChannel->communicationBus,
             ANTENNA_PRIMARY_CHANNEL,

--- a/libs/drivers/antenna/antenna.cpp
+++ b/libs/drivers/antenna/antenna.cpp
@@ -61,7 +61,7 @@ static OSResult HardReset(struct AntennaDriver* driver)
 static OSResult DeployAntenna(struct AntennaDriver* driver,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan timeout,
+    std::chrono::milliseconds timeout,
     bool overrideSwitches //
     )
 {
@@ -201,8 +201,8 @@ static void UpdateActivationTime(struct AntennaDriver* driver, AntennaTelemetry*
     AntennaChannelInfo* backupChannel = GetChannel(driver, ANTENNA_BACKUP_CHANNEL);
     for (int i = 0; i < 4; ++i)
     {
-        TimeSpan primaryValue(0);
-        TimeSpan secondaryValue(0);
+        std::chrono::milliseconds primaryValue(0);
+        std::chrono::milliseconds secondaryValue(0);
 
         const OSResult primary = driver->miniport->GetAntennaActivationTime(driver->miniport,
             primaryChannel->communicationBus,

--- a/libs/drivers/antenna/miniport.cpp
+++ b/libs/drivers/antenna/miniport.cpp
@@ -12,6 +12,7 @@ using drivers::i2c::I2CResult;
 using std::chrono::milliseconds;
 using std::chrono::seconds;
 using std::chrono::duration_cast;
+using namespace std::chrono_literals;
 
 /**
  * @brief Enumerator of all supported antenna controller commands.
@@ -271,7 +272,7 @@ static OSResult GetAntennaActivationTime(AntennaMiniportDriver* miniport,
 
     if (OS_RESULT_FAILED(result))
     {
-        *span = milliseconds(0);
+        *span = 0ms;
         return OSResult::IOError;
     }
 

--- a/libs/drivers/antenna/miniport.cpp
+++ b/libs/drivers/antenna/miniport.cpp
@@ -9,6 +9,9 @@
 using gsl::span;
 using drivers::i2c::II2CBus;
 using drivers::i2c::I2CResult;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
+using std::chrono::duration_cast;
 
 /**
  * @brief Enumerator of all supported antenna controller commands.
@@ -142,27 +145,27 @@ static OSResult DeployAntenna(struct AntennaMiniportDriver* miniport,
     II2CBus* communicationBus,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan timeout,
+    milliseconds timeout,
     bool override //
     )
 {
     UNREFERENCED_PARAMETER(miniport);
     uint8_t buffer[2];
     buffer[0] = (uint8_t)(DEPLOY_ANTENNA + antennaId + GetOverrideFlag(override));
-    buffer[1] = (uint8_t)TimeSpanToSeconds(timeout);
+    buffer[1] = (uint8_t)duration_cast<seconds>(timeout).count();
     return MapStatus(communicationBus->Write(channel, buffer));
 }
 
 static OSResult InitializeAutomaticDeployment(AntennaMiniportDriver* miniport,
     II2CBus* communicationBus,
     AntennaChannel channel,
-    TimeSpan timeout //
+    milliseconds timeout //
     )
 {
     UNREFERENCED_PARAMETER(miniport);
     uint8_t buffer[2];
     buffer[0] = (uint8_t)(START_AUTOMATIC_DEPLOYMENT);
-    buffer[1] = (uint8_t)TimeSpanToSeconds(timeout);
+    buffer[1] = (uint8_t)duration_cast<seconds>(timeout).count();
     return MapStatus(communicationBus->Write(channel, buffer));
 }
 
@@ -253,7 +256,7 @@ static OSResult GetAntennaActivationTime(AntennaMiniportDriver* miniport,
     II2CBus* communicationBus,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan* span //
+    milliseconds* span //
     )
 {
     UNREFERENCED_PARAMETER(miniport);
@@ -268,13 +271,13 @@ static OSResult GetAntennaActivationTime(AntennaMiniportDriver* miniport,
 
     if (OS_RESULT_FAILED(result))
     {
-        *span = TimeSpanFromMilliseconds(0);
+        *span = milliseconds(0);
         return OSResult::IOError;
     }
 
     Reader reader(output);
     const uint16_t value = reader.ReadWordBE();
-    *span = TimeSpanFromMilliseconds(value * 50);
+    *span = milliseconds(value * 50);
     return OSResult::Success;
 }
 

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -25,6 +25,7 @@ using drivers::i2c::II2CBus;
 using drivers::i2c::I2CResult;
 
 using namespace COMM;
+using namespace std::chrono_literals;
 
 Beacon::Beacon() : period(0)
 {
@@ -118,7 +119,7 @@ bool CommObject::Pause()
     if (this->_pollingTaskHandle != NULL)
     {
         System::EventGroupSetBits(this->_pollingTaskFlags, TaskFlagPauseRequest);
-        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, std::chrono::milliseconds(MAX_DELAY));
+        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, InfiniteTimeout);
     }
 
     return true;
@@ -474,8 +475,7 @@ void CommObject::CommTask(void* param)
     comm->PollHardware();
     for (;;)
     {
-        const OSEventBits result =
-            System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, std::chrono::seconds(10));
+        const OSEventBits result = System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, 10s);
         if (result == TaskFlagPauseRequest)
         {
             LOG(LOG_LEVEL_WARNING, "Comm task paused");

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -118,7 +118,7 @@ bool CommObject::Pause()
     if (this->_pollingTaskHandle != NULL)
     {
         System::EventGroupSetBits(this->_pollingTaskFlags, TaskFlagPauseRequest);
-        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, OSTaskTimeSpan(MAX_DELAY));
+        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, std::chrono::milliseconds(MAX_DELAY));
     }
 
     return true;
@@ -474,7 +474,8 @@ void CommObject::CommTask(void* param)
     comm->PollHardware();
     for (;;)
     {
-        const OSEventBits result =System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, OSTaskTimeSpan(10000));
+        const OSEventBits result =
+            System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, std::chrono::seconds(10));
         if (result == TaskFlagPauseRequest)
         {
             LOG(LOG_LEVEL_WARNING, "Comm task paused");

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -118,7 +118,7 @@ bool CommObject::Pause()
     if (this->_pollingTaskHandle != NULL)
     {
         System::EventGroupSetBits(this->_pollingTaskFlags, TaskFlagPauseRequest);
-        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, MAX_DELAY);
+        System::EventGroupWaitForBits(this->_pollingTaskFlags, TaskFlagAck, false, true, OSTaskTimeSpan(MAX_DELAY));
     }
 
     return true;
@@ -474,7 +474,7 @@ void CommObject::CommTask(void* param)
     comm->PollHardware();
     for (;;)
     {
-        const OSEventBits result = System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, 10000);
+        const OSEventBits result =System::EventGroupWaitForBits(comm->_pollingTaskFlags, TaskFlagPauseRequest, false, true, OSTaskTimeSpan(10000));
         if (result == TaskFlagPauseRequest)
         {
             LOG(LOG_LEVEL_WARNING, "Comm task paused");

--- a/libs/drivers/eps/eps.cpp
+++ b/libs/drivers/eps/eps.cpp
@@ -40,25 +40,25 @@ bool EpsOpenSail(void)
     {
         return false;
     }
-    System::SleepTask(100);
+    System::SleepTask(OSTaskTimeSpan(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_0, false))
     {
         return false;
     }
-    System::SleepTask(100);
+    System::SleepTask(OSTaskTimeSpan(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, true))
     {
         return false;
     }
-    System::SleepTask(100);
+    System::SleepTask(OSTaskTimeSpan(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, false))
     {
         return false;
     }
-    System::SleepTask(100);
+    System::SleepTask(OSTaskTimeSpan(100));
 
     return true;
 }

--- a/libs/drivers/eps/eps.cpp
+++ b/libs/drivers/eps/eps.cpp
@@ -7,6 +7,7 @@
 
 #include "system.h"
 
+using std::chrono::milliseconds;
 using drivers::i2c::II2CBus;
 using drivers::i2c::I2CResult;
 
@@ -40,25 +41,25 @@ bool EpsOpenSail(void)
     {
         return false;
     }
-    System::SleepTask(OSTaskTimeSpan(100));
+    System::SleepTask(milliseconds(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_0, false))
     {
         return false;
     }
-    System::SleepTask(OSTaskTimeSpan(100));
+    System::SleepTask(milliseconds(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, true))
     {
         return false;
     }
-    System::SleepTask(OSTaskTimeSpan(100));
+    System::SleepTask(milliseconds(100));
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, false))
     {
         return false;
     }
-    System::SleepTask(OSTaskTimeSpan(100));
+    System::SleepTask(milliseconds(100));
 
     return true;
 }

--- a/libs/drivers/eps/eps.cpp
+++ b/libs/drivers/eps/eps.cpp
@@ -7,9 +7,9 @@
 
 #include "system.h"
 
-using std::chrono::milliseconds;
 using drivers::i2c::II2CBus;
 using drivers::i2c::I2CResult;
+using namespace std::chrono_literals;
 
 #define EPS_ADDRESS 12
 
@@ -41,25 +41,25 @@ bool EpsOpenSail(void)
     {
         return false;
     }
-    System::SleepTask(milliseconds(100));
+    System::SleepTask(100ms);
 
     if (!epsControlLCL(EPS_LCL_SAIL_0, false))
     {
         return false;
     }
-    System::SleepTask(milliseconds(100));
+    System::SleepTask(100ms);
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, true))
     {
         return false;
     }
-    System::SleepTask(milliseconds(100));
+    System::SleepTask(100ms);
 
     if (!epsControlLCL(EPS_LCL_SAIL_1, false))
     {
         return false;
     }
-    System::SleepTask(milliseconds(100));
+    System::SleepTask(100ms);
 
     return true;
 }

--- a/libs/drivers/i2c/efm.cpp
+++ b/libs/drivers/i2c/efm.cpp
@@ -16,7 +16,7 @@ bool I2CLowLevelBus::IsSclLatched()
 
 I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
 {
-    Lock lock(this->_lock, MAX_DELAY);
+    Lock lock(this->_lock, OSTaskTimeSpan(MAX_DELAY));
 
     if (!lock())
     {
@@ -39,7 +39,7 @@ I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
         return (I2CResult)rawResult;
     }
 
-    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, io_map::I2C::Timeout * 1000)))
+    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, OSTaskTimeSpan(I2C_TIMEOUT * 1000))))
     {
         I2CResult ret = I2CResult::Timeout;
 

--- a/libs/drivers/i2c/efm.cpp
+++ b/libs/drivers/i2c/efm.cpp
@@ -16,7 +16,7 @@ bool I2CLowLevelBus::IsSclLatched()
 
 I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
 {
-    Lock lock(this->_lock, OSTaskTimeSpan(MAX_DELAY));
+    Lock lock(this->_lock, std::chrono::milliseconds(MAX_DELAY));
 
     if (!lock())
     {
@@ -39,7 +39,7 @@ I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
         return (I2CResult)rawResult;
     }
 
-    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, OSTaskTimeSpan(I2C_TIMEOUT * 1000))))
+    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, std::chrono::seconds(I2C_TIMEOUT))))
     {
         I2CResult ret = I2CResult::Timeout;
 

--- a/libs/drivers/i2c/efm.cpp
+++ b/libs/drivers/i2c/efm.cpp
@@ -39,7 +39,7 @@ I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
         return (I2CResult)rawResult;
     }
 
-    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, std::chrono::seconds(I2C_TIMEOUT))))
+    if (OS_RESULT_FAILED(this->_resultQueue.Pop(rawResult, std::chrono::seconds(static_cast<uint64_t>(io_map::I2C::Timeout)))))
     {
         I2CResult ret = I2CResult::Timeout;
 

--- a/libs/drivers/i2c/efm.cpp
+++ b/libs/drivers/i2c/efm.cpp
@@ -16,7 +16,7 @@ bool I2CLowLevelBus::IsSclLatched()
 
 I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
 {
-    Lock lock(this->_lock, std::chrono::milliseconds(MAX_DELAY));
+    Lock lock(this->_lock, InfiniteTimeout);
 
     if (!lock())
     {

--- a/libs/drivers/n25q/Include/n25q/n25q.h
+++ b/libs/drivers/n25q/Include/n25q/n25q.h
@@ -223,13 +223,13 @@ namespace devices
              * Datasheet states that this operation should take maximum 5 ms.
              * Rounded to 10ms as it is single FreeRTOS tick
              */
-            constexpr static std::uint32_t ProgramPageTimeout = 50;
+            static constexpr OSTaskTimeSpan ProgramPageTimeout = OSTaskTimeSpan(50);
             /** @brief Erase subsector operation timeout */
-            constexpr static std::uint32_t EraseSubSectorTimeout = 1.2 * (0.8 * 1000);
+            static constexpr OSTaskTimeSpan EraseSubSectorTimeout = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (0.8 * 1000)));
             /** @brief Erase sector operation timeout */
-            constexpr static std::uint32_t EraseSectorTimeout = 1.2 * (3 * 1000);
+            static constexpr OSTaskTimeSpan EraseSectorTimeout = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (3 * 1000)));
             /** @brief Erase chip operation timeout */
-            constexpr static std::uint32_t EraseChipTimeOut = 1.2 * (250 * 1000);
+            static constexpr OSTaskTimeSpan EraseChipTimeOut = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (250 * 1000)));
             /** @brief Reset timeout */
             constexpr static std::uint32_t ResetTimeout = 10;
             /** @brief Write status register timeout */

--- a/libs/drivers/n25q/Include/n25q/n25q.h
+++ b/libs/drivers/n25q/Include/n25q/n25q.h
@@ -225,8 +225,7 @@ namespace devices
              */
             static constexpr std::chrono::milliseconds ProgramPageTimeout = std::chrono::milliseconds(50);
             /** @brief Erase subsector operation timeout */
-            static constexpr std::chrono::milliseconds EraseSubSectorTimeout =
-                std::chrono::milliseconds(static_cast<int64_t>(1.2 * (0.8 * 1000)));
+            static constexpr std::chrono::milliseconds EraseSubSectorTimeout = std::chrono::milliseconds(static_cast<int64_t>(1.2 * 800));
             /** @brief Erase sector operation timeout */
             static constexpr std::chrono::seconds EraseSectorTimeout = std::chrono::seconds(static_cast<int64_t>(1.2 * 3));
             /** @brief Erase chip operation timeout */

--- a/libs/drivers/n25q/Include/n25q/n25q.h
+++ b/libs/drivers/n25q/Include/n25q/n25q.h
@@ -226,13 +226,11 @@ namespace devices
             static constexpr std::chrono::milliseconds ProgramPageTimeout = std::chrono::milliseconds(50);
             /** @brief Erase subsector operation timeout */
             static constexpr std::chrono::milliseconds EraseSubSectorTimeout =
-                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (0.8 * 1000)));
+                std::chrono::milliseconds(static_cast<int64_t>(1.2 * (0.8 * 1000)));
             /** @brief Erase sector operation timeout */
-            static constexpr std::chrono::milliseconds EraseSectorTimeout =
-                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (3 * 1000)));
+            static constexpr std::chrono::seconds EraseSectorTimeout = std::chrono::seconds(static_cast<int64_t>(1.2 * 3));
             /** @brief Erase chip operation timeout */
-            static constexpr std::chrono::milliseconds EraseChipTimeOut =
-                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (250 * 1000)));
+            static constexpr std::chrono::seconds EraseChipTimeOut = std::chrono::seconds(static_cast<int64_t>(1.2 * 250));
             /** @brief Reset timeout */
             static constexpr std::chrono::milliseconds ResetTimeout = std::chrono::milliseconds(10);
             /** @brief Write status register timeout */

--- a/libs/drivers/n25q/Include/n25q/n25q.h
+++ b/libs/drivers/n25q/Include/n25q/n25q.h
@@ -196,7 +196,7 @@ namespace devices
              * @param[in] timeout Timeout
              * @return true of operation finished, false on timeout
              */
-            bool WaitBusy(OSTaskTimeSpan timeout);
+            bool WaitBusy(std::chrono::milliseconds timeout);
 
             /**
              * @brief Outputs specified address to device
@@ -223,13 +223,16 @@ namespace devices
              * Datasheet states that this operation should take maximum 5 ms.
              * Rounded to 10ms as it is single FreeRTOS tick
              */
-            static constexpr OSTaskTimeSpan ProgramPageTimeout = OSTaskTimeSpan(50);
+            static constexpr std::chrono::milliseconds ProgramPageTimeout = std::chrono::milliseconds(50);
             /** @brief Erase subsector operation timeout */
-            static constexpr OSTaskTimeSpan EraseSubSectorTimeout = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (0.8 * 1000)));
+            static constexpr std::chrono::milliseconds EraseSubSectorTimeout =
+                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (0.8 * 1000)));
             /** @brief Erase sector operation timeout */
-            static constexpr OSTaskTimeSpan EraseSectorTimeout = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (3 * 1000)));
+            static constexpr std::chrono::milliseconds EraseSectorTimeout =
+                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (3 * 1000)));
             /** @brief Erase chip operation timeout */
-            static constexpr OSTaskTimeSpan EraseChipTimeOut = OSTaskTimeSpan(static_cast<uint64_t>(1.2 * (250 * 1000)));
+            static constexpr std::chrono::milliseconds EraseChipTimeOut =
+                std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (250 * 1000)));
             /** @brief Reset timeout */
             constexpr static std::uint32_t ResetTimeout = 10;
             /** @brief Write status register timeout */

--- a/libs/drivers/n25q/Include/n25q/n25q.h
+++ b/libs/drivers/n25q/Include/n25q/n25q.h
@@ -234,9 +234,9 @@ namespace devices
             static constexpr std::chrono::milliseconds EraseChipTimeOut =
                 std::chrono::milliseconds(static_cast<uint64_t>(1.2 * (250 * 1000)));
             /** @brief Reset timeout */
-            constexpr static std::uint32_t ResetTimeout = 10;
+            static constexpr std::chrono::milliseconds ResetTimeout = std::chrono::milliseconds(10);
             /** @brief Write status register timeout */
-            constexpr static std::uint32_t WriteStatusRegisterTimeout = 10;
+            static constexpr std::chrono::milliseconds WriteStatusRegisterTimeout = std::chrono::milliseconds(10);
         };
     }
 }

--- a/libs/drivers/n25q/n25q.cpp
+++ b/libs/drivers/n25q/n25q.cpp
@@ -36,10 +36,10 @@ enum N25QCommand
     WriteStatusRegister = 0x01
 };
 
-constexpr OSTaskTimeSpan N25QDriver::ProgramPageTimeout;
-constexpr OSTaskTimeSpan N25QDriver::EraseSubSectorTimeout;
-constexpr OSTaskTimeSpan N25QDriver::EraseSectorTimeout;
-constexpr OSTaskTimeSpan N25QDriver::EraseChipTimeOut;
+constexpr std::chrono::milliseconds N25QDriver::ProgramPageTimeout;
+constexpr std::chrono::milliseconds N25QDriver::EraseSubSectorTimeout;
+constexpr std::chrono::milliseconds N25QDriver::EraseSectorTimeout;
+constexpr std::chrono::milliseconds N25QDriver::EraseChipTimeOut;
 
 static inline void WriterWriteAddress(Writer* writer, size_t address)
 {
@@ -167,7 +167,7 @@ void N25QDriver::EnableWrite()
     this->Command(N25QCommand::WriteEnable);
 }
 
-bool N25QDriver::WaitBusy(OSTaskTimeSpan timeout)
+bool N25QDriver::WaitBusy(std::chrono::milliseconds timeout)
 {
     Timeout timeoutCheck(timeout);
 

--- a/libs/drivers/n25q/n25q.cpp
+++ b/libs/drivers/n25q/n25q.cpp
@@ -36,6 +36,11 @@ enum N25QCommand
     WriteStatusRegister = 0x01
 };
 
+constexpr OSTaskTimeSpan N25QDriver::ProgramPageTimeout;
+constexpr OSTaskTimeSpan N25QDriver::EraseSubSectorTimeout;
+constexpr OSTaskTimeSpan N25QDriver::EraseSectorTimeout;
+constexpr OSTaskTimeSpan N25QDriver::EraseChipTimeOut;
+
 static inline void WriterWriteAddress(Writer* writer, size_t address)
 {
     WriterWriteByte(writer, static_cast<uint8_t>((address >> 2 * 8) & 0xFF));

--- a/libs/drivers/n25q/n25q.cpp
+++ b/libs/drivers/n25q/n25q.cpp
@@ -38,8 +38,8 @@ enum N25QCommand
 
 constexpr std::chrono::milliseconds N25QDriver::ProgramPageTimeout;
 constexpr std::chrono::milliseconds N25QDriver::EraseSubSectorTimeout;
-constexpr std::chrono::milliseconds N25QDriver::EraseSectorTimeout;
-constexpr std::chrono::milliseconds N25QDriver::EraseChipTimeOut;
+constexpr std::chrono::seconds N25QDriver::EraseSectorTimeout;
+constexpr std::chrono::seconds N25QDriver::EraseChipTimeOut;
 constexpr std::chrono::milliseconds N25QDriver::ResetTimeout;
 constexpr std::chrono::milliseconds N25QDriver::WriteStatusRegisterTimeout;
 

--- a/libs/drivers/n25q/n25q.cpp
+++ b/libs/drivers/n25q/n25q.cpp
@@ -40,6 +40,8 @@ constexpr std::chrono::milliseconds N25QDriver::ProgramPageTimeout;
 constexpr std::chrono::milliseconds N25QDriver::EraseSubSectorTimeout;
 constexpr std::chrono::milliseconds N25QDriver::EraseSectorTimeout;
 constexpr std::chrono::milliseconds N25QDriver::EraseChipTimeOut;
+constexpr std::chrono::milliseconds N25QDriver::ResetTimeout;
+constexpr std::chrono::milliseconds N25QDriver::WriteStatusRegisterTimeout;
 
 static inline void WriterWriteAddress(Writer* writer, size_t address)
 {

--- a/libs/drivers/spi/efm.cpp
+++ b/libs/drivers/spi/efm.cpp
@@ -74,7 +74,7 @@ void EFMSPIInterface::Write(gsl::span<const std::uint8_t> buffer)
         OnTransferFinished,
         this);
 
-    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, std::chrono::milliseconds(MAX_DELAY));
+    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, InfiniteTimeout);
 }
 
 void EFMSPIInterface::Read(gsl::span<std::uint8_t> buffer)
@@ -106,7 +106,7 @@ void EFMSPIInterface::Read(gsl::span<std::uint8_t> buffer)
         OnTransferFinished,
         this);
 
-    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, std::chrono::milliseconds(MAX_DELAY));
+    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, InfiniteTimeout);
 }
 
 bool EFMSPIInterface::OnTransferFinished(unsigned int channel, unsigned int sequenceNo, void* param)
@@ -156,7 +156,7 @@ void EFMSPISlaveInterface::Read(gsl::span<std::uint8_t> buffer)
 
 void drivers::spi::EFMSPIInterface::Lock()
 {
-    System::TakeSemaphore(this->_lock, std::chrono::milliseconds(MAX_DELAY));
+    System::TakeSemaphore(this->_lock, InfiniteTimeout);
 }
 
 void drivers::spi::EFMSPIInterface::Unlock()

--- a/libs/drivers/spi/efm.cpp
+++ b/libs/drivers/spi/efm.cpp
@@ -74,7 +74,7 @@ void EFMSPIInterface::Write(gsl::span<const std::uint8_t> buffer)
         OnTransferFinished,
         this);
 
-    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, MAX_DELAY);
+    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, std::chrono::milliseconds(MAX_DELAY));
 }
 
 void EFMSPIInterface::Read(gsl::span<std::uint8_t> buffer)
@@ -106,7 +106,7 @@ void EFMSPIInterface::Read(gsl::span<std::uint8_t> buffer)
         OnTransferFinished,
         this);
 
-    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, MAX_DELAY);
+    System::EventGroupWaitForBits(this->_transferGroup, TransferFinished, true, true, std::chrono::milliseconds(MAX_DELAY));
 }
 
 bool EFMSPIInterface::OnTransferFinished(unsigned int channel, unsigned int sequenceNo, void* param)
@@ -156,7 +156,7 @@ void EFMSPISlaveInterface::Read(gsl::span<std::uint8_t> buffer)
 
 void drivers::spi::EFMSPIInterface::Lock()
 {
-    System::TakeSemaphore(this->_lock, MAX_DELAY);
+    System::TakeSemaphore(this->_lock, std::chrono::milliseconds(MAX_DELAY));
 }
 
 void drivers::spi::EFMSPIInterface::Unlock()

--- a/libs/free_rtos_wrapper/os.cpp
+++ b/libs/free_rtos_wrapper/os.cpp
@@ -12,7 +12,7 @@
 static_assert(static_cast<uint8_t>(TaskPriority::Idle) == 0, "Idle priority must be 0");
 static_assert(static_cast<uint8_t>(TaskPriority::Highest) < configMAX_PRIORITIES, "Priorites up to configMAX_PRIORITIES - 1 are allowed");
 
-static inline TickType_t ConvertTimeToTicks(const OSTaskTimeSpan span)
+static inline TickType_t ConvertTimeToTicks(const std::chrono::milliseconds span)
 {
     const uint64_t time = span.count();
 
@@ -48,7 +48,7 @@ void System::RunScheduler(void)
     vTaskStartScheduler();
 }
 
-void System::SleepTask(const OSTaskTimeSpan time)
+void System::SleepTask(const std::chrono::milliseconds time)
 {
     vTaskDelay(ConvertTimeToTicks(time));
 }
@@ -76,7 +76,7 @@ OSSemaphoreHandle System::CreateBinarySemaphore(uint8_t semaphoreId)
     return s;
 }
 
-OSResult System::TakeSemaphore(OSSemaphoreHandle semaphore, OSTaskTimeSpan timeout)
+OSResult System::TakeSemaphore(OSSemaphoreHandle semaphore, std::chrono::milliseconds timeout)
 {
     const BaseType_t result = xSemaphoreTake(semaphore, ConvertTimeToTicks(timeout));
     if (result != pdPASS)
@@ -139,7 +139,7 @@ OSEventBits System::EventGroupWaitForBits(OSEventGroupHandle eventGroup, //
     const OSEventBits bitsToWaitFor,                                     //
     bool waitAll,                                                        //
     bool autoReset,                                                      //
-    const OSTaskTimeSpan timeout                                         //
+    const std::chrono::milliseconds timeout                              //
     )
 {
     return xEventGroupWaitBits(eventGroup, //
@@ -166,7 +166,7 @@ OSQueueHandle System::CreateQueue(size_t maxElementCount, size_t elementSize)
     return xQueueCreate(maxElementCount, elementSize);
 }
 
-bool System::QueueReceive(OSQueueHandle queue, void* element, OSTaskTimeSpan timeout)
+bool System::QueueReceive(OSQueueHandle queue, void* element, std::chrono::milliseconds timeout)
 {
     return xQueueReceive(queue, element, ConvertTimeToTicks(timeout)) == pdTRUE;
 }
@@ -178,7 +178,7 @@ bool System::QueueReceiveFromISR(OSQueueHandle queue, void* element)
     return result;
 }
 
-bool System::QueueSend(OSQueueHandle queue, const void* element, OSTaskTimeSpan timeout)
+bool System::QueueSend(OSQueueHandle queue, const void* element, std::chrono::milliseconds timeout)
 {
     return xQueueSend(queue, element, ConvertTimeToTicks(timeout)) == pdTRUE;
 }
@@ -205,7 +205,7 @@ OSPulseHandle System::CreatePulseAll(void)
     return (OSPulseHandle)System::CreateEventGroup();
 }
 
-OSResult System::PulseWait(OSPulseHandle handle, OSTaskTimeSpan timeout)
+OSResult System::PulseWait(OSPulseHandle handle, std::chrono::milliseconds timeout)
 {
     OSEventBits result = System::EventGroupWaitForBits((OSEventGroupHandle)handle, PULSE_ALL_BITS, true, true, timeout);
 
@@ -224,9 +224,9 @@ void System::PulseSet(OSPulseHandle handle)
     System::EventGroupSetBits((OSEventGroupHandle)handle, PULSE_ALL_BITS);
 }
 
-OSTaskTimeSpan System::GetUptime()
+std::chrono::milliseconds System::GetUptime()
 {
-    return OSTaskTimeSpan(static_cast<uint64_t>(portTICK_PERIOD_MS * xTaskGetTickCount()));
+    return std::chrono::milliseconds(static_cast<uint64_t>(portTICK_PERIOD_MS * xTaskGetTickCount()));
 }
 
 void System::Yield()

--- a/libs/free_rtos_wrapper/os.cpp
+++ b/libs/free_rtos_wrapper/os.cpp
@@ -14,12 +14,13 @@ static_assert(static_cast<uint8_t>(TaskPriority::Highest) < configMAX_PRIORITIES
 
 static inline TickType_t ConvertTimeToTicks(const OSTaskTimeSpan span)
 {
-    if (span == MAX_DELAY)
+    const uint64_t time = span.count();
+
+    if (time == MAX_DELAY)
     {
         return portMAX_DELAY;
     }
 
-    const uint64_t time = span;
     return pdMS_TO_TICKS(time);
 }
 
@@ -225,7 +226,7 @@ void System::PulseSet(OSPulseHandle handle)
 
 OSTaskTimeSpan System::GetUptime()
 {
-    return portTICK_PERIOD_MS * xTaskGetTickCount();
+    return OSTaskTimeSpan(static_cast<uint64_t>(portTICK_PERIOD_MS * xTaskGetTickCount()));
 }
 
 void System::Yield()

--- a/libs/mission/Include/mission/main.hpp
+++ b/libs/mission/Include/mission/main.hpp
@@ -309,7 +309,7 @@ namespace mission
         if (this->taskHandle != nullptr)
         {
             System::EventGroupSetBits(this->eventGroup, PauseRequestFlag);
-            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, MAX_DELAY);
+            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, OSTaskTimeSpan(MAX_DELAY));
         }
     }
 
@@ -357,7 +357,8 @@ namespace mission
         LOG(LOG_LEVEL_DEBUG, "Starting mission control task");
         for (;;)
         {
-            const OSEventBits result = System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, 10000);
+            const OSEventBits result =
+                System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, OSTaskTimeSpan(10000));
             if (result == PauseRequestFlag)
             {
                 LOG(LOG_LEVEL_WARNING, "MissionLoop task paused");

--- a/libs/mission/Include/mission/main.hpp
+++ b/libs/mission/Include/mission/main.hpp
@@ -309,7 +309,7 @@ namespace mission
         if (this->taskHandle != nullptr)
         {
             System::EventGroupSetBits(this->eventGroup, PauseRequestFlag);
-            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, OSTaskTimeSpan(MAX_DELAY));
+            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, std::chrono::milliseconds(MAX_DELAY));
         }
     }
 
@@ -358,7 +358,7 @@ namespace mission
         for (;;)
         {
             const OSEventBits result =
-                System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, OSTaskTimeSpan(10000));
+                System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, std::chrono::seconds(10));
             if (result == PauseRequestFlag)
             {
                 LOG(LOG_LEVEL_WARNING, "MissionLoop task paused");

--- a/libs/mission/Include/mission/main.hpp
+++ b/libs/mission/Include/mission/main.hpp
@@ -12,6 +12,8 @@
 #include "logic.hpp"
 #include "traits.hpp"
 
+using namespace std::chrono_literals;
+
 namespace mission
 {
     /**
@@ -309,7 +311,7 @@ namespace mission
         if (this->taskHandle != nullptr)
         {
             System::EventGroupSetBits(this->eventGroup, PauseRequestFlag);
-            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, std::chrono::milliseconds(MAX_DELAY));
+            System::EventGroupWaitForBits(this->eventGroup, PauseAckFlag, false, true, InfiniteTimeout);
         }
     }
 
@@ -357,8 +359,7 @@ namespace mission
         LOG(LOG_LEVEL_DEBUG, "Starting mission control task");
         for (;;)
         {
-            const OSEventBits result =
-                System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, std::chrono::seconds(10));
+            const OSEventBits result = System::EventGroupWaitForBits(this->eventGroup, PauseRequestFlag, false, true, 10s);
             if (result == PauseRequestFlag)
             {
                 LOG(LOG_LEVEL_WARNING, "MissionLoop task paused");

--- a/libs/mission/antenna/antenna.cpp
+++ b/libs/mission/antenna/antenna.cpp
@@ -8,6 +8,8 @@
 #include "system.h"
 #include "time/TimePoint.h"
 
+using namespace std::chrono_literals;
+
 namespace mission
 {
     namespace antenna
@@ -434,7 +436,7 @@ namespace mission
         static bool AntennaDeploymentCondition(const SystemState& state, void* param)
         {
             AntennaMissionState* stateDescriptor = (AntennaMissionState*)param;
-            const auto t = std::chrono::minutes(40);
+            const auto t = 40min;
             if (state.Time < t)
             {
                 return false;

--- a/libs/mission/antenna/antenna.cpp
+++ b/libs/mission/antenna/antenna.cpp
@@ -332,7 +332,7 @@ namespace mission
                 const OSResult result = driver.DeployAntenna(&driver,
                     step.channel,
                     step.antennaId,
-                    TimeSpanFromSeconds(step.deploymentTimeout),
+                    std::chrono::seconds(step.deploymentTimeout),
                     step.overrideSwitches //
                     );
 
@@ -434,7 +434,7 @@ namespace mission
         static bool AntennaDeploymentCondition(const SystemState& state, void* param)
         {
             AntennaMissionState* stateDescriptor = (AntennaMissionState*)param;
-            const TimeSpan t = TimeSpanFromMinutes(40);
+            const auto t = std::chrono::minutes(40);
             if (state.Time < t)
             {
                 return false;

--- a/libs/mission/antenna/antenna.cpp
+++ b/libs/mission/antenna/antenna.cpp
@@ -435,7 +435,7 @@ namespace mission
         {
             AntennaMissionState* stateDescriptor = (AntennaMissionState*)param;
             const TimeSpan t = TimeSpanFromMinutes(40);
-            if (TimeSpanLessThan(state.Time, t))
+            if (state.Time < t)
             {
                 return false;
             }

--- a/libs/mission/sail/sail.cpp
+++ b/libs/mission/sail/sail.cpp
@@ -2,6 +2,8 @@
 #include "eps/eps.h"
 #include "state/struct.h"
 
+using namespace std::chrono_literals;
+
 namespace mission
 {
     SailTask::SailTask(bool isSailOpened) : state(isSailOpened)
@@ -38,7 +40,7 @@ namespace mission
     {
         UNREFERENCED_PARAMETER(param);
 
-        const auto t = std::chrono::hours(40);
+        const auto t = 40h;
         if (state.Time < t)
         {
             return false;

--- a/libs/mission/sail/sail.cpp
+++ b/libs/mission/sail/sail.cpp
@@ -38,7 +38,7 @@ namespace mission
     {
         UNREFERENCED_PARAMETER(param);
 
-        const TimeSpan t = TimeSpanFromHours(40);
+        const auto t = std::chrono::hours(40);
         if (state.Time < t)
         {
             return false;

--- a/libs/mission/sail/sail.cpp
+++ b/libs/mission/sail/sail.cpp
@@ -39,7 +39,7 @@ namespace mission
         UNREFERENCED_PARAMETER(param);
 
         const TimeSpan t = TimeSpanFromHours(40);
-        if (TimeSpanLessThan(state.Time, t))
+        if (state.Time < t)
         {
             return false;
         }

--- a/libs/mission/time/time.cpp
+++ b/libs/mission/time/time.cpp
@@ -12,7 +12,7 @@ namespace mission
     UpdateResult TimeTask::UpdateProc(SystemState& state, void* param)
     {
         auto timeProvider = static_cast<TimeProvider*>(param);
-        Option<TimeSpan> currentTime = timeProvider->GetCurrentTime();
+        Option<std::chrono::milliseconds> currentTime = timeProvider->GetCurrentTime();
 
         if (currentTime.HasValue)
         {

--- a/libs/state/Include/state/struct.h
+++ b/libs/state/Include/state/struct.h
@@ -22,7 +22,7 @@ struct SystemState
     SystemState();
 
     /** @brief Current time */
-    TimeSpan Time;
+    std::chrono::milliseconds Time;
 
     /**
      * @brief Current antenna deployment state.

--- a/libs/state/state.cpp
+++ b/libs/state/state.cpp
@@ -2,7 +2,7 @@
 #include "struct.h"
 
 SystemState::SystemState() //
-    : Time(TimeSpanFromMilliseconds(0)),
+    : Time(std::chrono::milliseconds(0)),
       SailOpened(false)
 {
     Antenna.Deployed = false;

--- a/libs/state/state.cpp
+++ b/libs/state/state.cpp
@@ -1,8 +1,10 @@
 #include <cstring>
 #include "struct.h"
 
+using namespace std::chrono_literals;
+
 SystemState::SystemState() //
-    : Time(std::chrono::milliseconds(0)),
+    : Time(0ms),
       SailOpened(false)
 {
     Antenna.Deployed = false;

--- a/libs/time/TimePoint.cpp
+++ b/libs/time/TimePoint.cpp
@@ -2,33 +2,32 @@
 
 TimeSpan TimeSpanFromMilliseconds(uint64_t milliseconds)
 {
-    const TimeSpan span(milliseconds);
-    return span;
+    return std::chrono::duration_cast<TimeSpan>(std::chrono::milliseconds(milliseconds));
 }
 
 TimeSpan TimeSpanFromSeconds(uint32_t seconds)
 {
-    return TimeSpanFromMilliseconds(seconds * 1000ull);
+    return std::chrono::duration_cast<TimeSpan>(std::chrono::seconds(seconds));
 }
 
 TimeSpan TimeSpanFromMinutes(uint32_t minutes)
 {
-    return TimeSpanFromMilliseconds(minutes * 60000ull);
+    return std::chrono::duration_cast<TimeSpan>(std::chrono::minutes(minutes));
 }
 
 TimeSpan TimeSpanFromHours(uint32_t hours)
 {
-    return TimeSpanFromMilliseconds(hours * 3600000ull);
+    return std::chrono::duration_cast<TimeSpan>(std::chrono::hours(hours));
 }
 
 TimeSpan TimeSpanFromDays(uint32_t days)
 {
-    return TimeSpanFromMilliseconds(days * 24ull * 3600000ull);
+    return std::chrono::duration_cast<TimeSpan>(std::chrono::hours(days * 24));
 }
 
 uint32_t TimeSpanToSeconds(TimeSpan span)
 {
-    return span.count() / 1000;
+    return std::chrono::duration_cast<std::chrono::seconds>(span).count();
 }
 
 TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond)
@@ -50,7 +49,7 @@ TimePoint TimePointNormalize(TimePoint point)
 TimePoint TimePointFromTimeSpan(const TimeSpan timeSpan)
 {
     TimePoint point = {};
-    uint64_t span = timeSpan.count();
+    uint64_t span = std::chrono::duration_cast<std::chrono::milliseconds>(timeSpan).count();
     point.milisecond = span % 1000;
     span /= 1000;
     point.second = span % 60;

--- a/libs/time/TimePoint.cpp
+++ b/libs/time/TimePoint.cpp
@@ -21,10 +21,10 @@ TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t sec
 
 TimePoint TimePointNormalize(TimePoint point)
 {
-    return TimePointFromTimeSpan(TimePointToTimeSpan(point));
+    return TimePointFromDuration(TimePointToTimeSpan(point));
 }
 
-TimePoint TimePointFromTimeSpan(const milliseconds timeSpan)
+TimePoint TimePointFromDuration(const milliseconds timeSpan)
 {
     TimePoint point = {};
     uint64_t span = timeSpan.count();

--- a/libs/time/TimePoint.cpp
+++ b/libs/time/TimePoint.cpp
@@ -28,7 +28,7 @@ TimeSpan TimeSpanFromDays(uint32_t days)
 
 uint32_t TimeSpanToSeconds(TimeSpan span)
 {
-    return std::chrono::duration_cast<std::chrono::duration<uint32_t>>(span).count();
+    return span.count() / 1000;
 }
 
 TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond)
@@ -74,15 +74,4 @@ TimeSpan TimePointToTimeSpan(TimePoint point)
     result *= 1000;
     result += point.milisecond;
     return TimeSpanFromMilliseconds(result);
-}
-
-TimeSpan TimeSpanAdd(TimeSpan left, TimeSpan right)
-{
-    left += right;
-    return left;
-}
-
-TimeShift TimeSpanSub(TimeSpan left, TimeSpan right)
-{
-    return left - right;
 }

--- a/libs/time/TimePoint.cpp
+++ b/libs/time/TimePoint.cpp
@@ -1,33 +1,11 @@
 #include "TimePoint.h"
 
-TimeSpan TimeSpanFromMilliseconds(uint64_t milliseconds)
-{
-    return std::chrono::duration_cast<TimeSpan>(std::chrono::milliseconds(milliseconds));
-}
+using std::chrono::milliseconds;
+using std::chrono::duration_cast;
 
-TimeSpan TimeSpanFromSeconds(uint32_t seconds)
+milliseconds TimeSpanFromDays(uint32_t days)
 {
-    return std::chrono::duration_cast<TimeSpan>(std::chrono::seconds(seconds));
-}
-
-TimeSpan TimeSpanFromMinutes(uint32_t minutes)
-{
-    return std::chrono::duration_cast<TimeSpan>(std::chrono::minutes(minutes));
-}
-
-TimeSpan TimeSpanFromHours(uint32_t hours)
-{
-    return std::chrono::duration_cast<TimeSpan>(std::chrono::hours(hours));
-}
-
-TimeSpan TimeSpanFromDays(uint32_t days)
-{
-    return std::chrono::duration_cast<TimeSpan>(std::chrono::hours(days * 24));
-}
-
-uint32_t TimeSpanToSeconds(TimeSpan span)
-{
-    return std::chrono::duration_cast<std::chrono::seconds>(span).count();
+    return duration_cast<milliseconds>(std::chrono::hours(days * 24));
 }
 
 TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond)
@@ -46,10 +24,10 @@ TimePoint TimePointNormalize(TimePoint point)
     return TimePointFromTimeSpan(TimePointToTimeSpan(point));
 }
 
-TimePoint TimePointFromTimeSpan(const TimeSpan timeSpan)
+TimePoint TimePointFromTimeSpan(const milliseconds timeSpan)
 {
     TimePoint point = {};
-    uint64_t span = std::chrono::duration_cast<std::chrono::milliseconds>(timeSpan).count();
+    uint64_t span = timeSpan.count();
     point.milisecond = span % 1000;
     span /= 1000;
     point.second = span % 60;
@@ -61,7 +39,7 @@ TimePoint TimePointFromTimeSpan(const TimeSpan timeSpan)
     return point;
 }
 
-TimeSpan TimePointToTimeSpan(TimePoint point)
+milliseconds TimePointToTimeSpan(TimePoint point)
 {
     uint64_t result = point.day;
     result *= 24;
@@ -72,5 +50,5 @@ TimeSpan TimePointToTimeSpan(TimePoint point)
     result += point.second;
     result *= 1000;
     result += point.milisecond;
-    return TimeSpanFromMilliseconds(result);
+    return milliseconds(result);
 }

--- a/libs/time/TimePoint.cpp
+++ b/libs/time/TimePoint.cpp
@@ -2,7 +2,7 @@
 
 TimeSpan TimeSpanFromMilliseconds(uint64_t milliseconds)
 {
-    const TimeSpan span = {milliseconds};
+    const TimeSpan span(milliseconds);
     return span;
 }
 
@@ -28,7 +28,7 @@ TimeSpan TimeSpanFromDays(uint32_t days)
 
 uint32_t TimeSpanToSeconds(TimeSpan span)
 {
-    return span.value / 1000;
+    return std::chrono::duration_cast<std::chrono::duration<uint32_t>>(span).count();
 }
 
 TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond)
@@ -50,7 +50,7 @@ TimePoint TimePointNormalize(TimePoint point)
 TimePoint TimePointFromTimeSpan(const TimeSpan timeSpan)
 {
     TimePoint point = {};
-    uint64_t span = timeSpan.value;
+    uint64_t span = timeSpan.count();
     point.milisecond = span % 1000;
     span /= 1000;
     point.second = span % 60;
@@ -78,12 +78,11 @@ TimeSpan TimePointToTimeSpan(TimePoint point)
 
 TimeSpan TimeSpanAdd(TimeSpan left, TimeSpan right)
 {
-    left.value += right.value;
+    left += right;
     return left;
 }
 
 TimeShift TimeSpanSub(TimeSpan left, TimeSpan right)
 {
-    const TimeShift result = {static_cast<uint8_t>(left.value - right.value)};
-    return result;
+    return left - right;
 }

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -38,7 +38,7 @@ typedef struct
  * The point with zero time (beginning of time) is considered to be
  * beginning of the mission itself.
  */
-typedef std::chrono::duration<uint64_t, std::milli> TimeSpan;
+typedef std::chrono::milliseconds TimeSpan;
 
 /**
  * @brief Creates TimeSpan object initialized from time specified in milliseconds.

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -15,24 +15,6 @@ EXTERNC_BEGIN
  * @{
  */
 
-// struct MissionClock
-//{
-//    typedef std::chrono::miliseconds          duration;
-//    typedef duration::rep                     rep;
-//    typedef duration::period                  period;
-//    typedef std::chrono::time_point<MissionClock> time_point;
-//    static const bool is_steady =             false;
-//
-//    static time_point now() noexcept
-//    {
-//        using namespace std::chrono;
-//        return time_point
-//          (
-//
-//          );
-//    }
-//};
-
 /**
  * @brief Structure that contains decoded point in time.
  *
@@ -57,11 +39,6 @@ typedef struct
  * beginning of the mission itself.
  */
 typedef std::chrono::duration<uint64_t, std::milli> TimeSpan;
-
-/**
- * @brief Type used to represents different between two time spans.
- */
-typedef std::chrono::duration<uint64_t, std::milli> TimeShift;
 
 /**
  * @brief Creates TimeSpan object initialized from time specified in milliseconds.
@@ -97,46 +74,6 @@ TimeSpan TimeSpanFromHours(uint32_t hours);
  * @return Prepared time span object.
  */
 TimeSpan TimeSpanFromDays(uint32_t days);
-
-/**
- * @brief Adds together two TimeSpan objects.
- * @param[in] left TimeSpan value to add.
- * @param[in] right TimeSpan value to add.
- * @return Addition result.
- */
-TimeSpan TimeSpanAdd(TimeSpan left, TimeSpan right);
-
-/**
- * @brief Subtracts two TimeSpan objects.
- * @param[in] left TimeSpan value to subtract from.
- * @param[in] right TimeSpan value to be subtracted.
- * @return Subtraction result.
- */
-TimeShift TimeSpanSub(TimeSpan left, TimeSpan right);
-
-/**
- * @brief Compares two TimeSpan objects.
- * @param[in] left TimeSpan value to compare.
- * @param[in] right TimeSpan value to compare.
- * @return Comparison result. True when two TimeSpans are equal, false otherwise.
- */
-static bool TimeSpanEqual(const TimeSpan left, const TimeSpan right);
-
-/**
- * @brief Compares two TimeSpan objects.
- * @param[in] left TimeSpan value to compare.
- * @param[in] right TimeSpan value to compare.
- * @return Comparison result. True when two TimeSpans are not equal, false otherwise.
- */
-static bool TimeSpanNotEqual(const TimeSpan left, const TimeSpan right);
-
-/**
- * @brief Determines whether left TimeSpan object is strictly smaller than right object.
- * @param[in] left TimeSpan value to compare.
- * @param[in] right TimeSpan value to compare.
- * @return Comparison result. True when left TimeSpan object is strictly smaller than right object, false otherwise.
- */
-static bool TimeSpanLessThan(const TimeSpan left, const TimeSpan right);
 
 /**
  * @brief This procedure builds Time point object.
@@ -223,27 +160,12 @@ static inline bool TimePointNotEqual(TimePoint left, TimePoint right)
 
 static inline bool TimePointEqual(TimePoint left, TimePoint right)
 {
-    return TimeSpanEqual(TimePointToTimeSpan(left), TimePointToTimeSpan(right));
+    return TimePointToTimeSpan(left) == TimePointToTimeSpan(right);
 }
 
 static inline bool TimePointLessThan(TimePoint left, TimePoint right)
 {
-    return TimeSpanLessThan(TimePointToTimeSpan(left), TimePointToTimeSpan(right));
-}
-
-static inline bool TimeSpanEqual(const TimeSpan left, const TimeSpan right)
-{
-    return left == right;
-}
-
-static inline bool TimeSpanNotEqual(const TimeSpan left, const TimeSpan right)
-{
-    return left != right;
-}
-
-static inline bool TimeSpanLessThan(const TimeSpan left, const TimeSpan right)
-{
-    return left < right;
+    return TimePointToTimeSpan(left) < TimePointToTimeSpan(right);
 }
 
 /** @} */

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -5,6 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <chrono>
 #include "system.h"
 
 EXTERNC_BEGIN
@@ -13,6 +14,24 @@ EXTERNC_BEGIN
  * @addtogroup time
  * @{
  */
+
+// struct MissionClock
+//{
+//    typedef std::chrono::miliseconds          duration;
+//    typedef duration::rep                     rep;
+//    typedef duration::period                  period;
+//    typedef std::chrono::time_point<MissionClock> time_point;
+//    static const bool is_steady =             false;
+//
+//    static time_point now() noexcept
+//    {
+//        using namespace std::chrono;
+//        return time_point
+//          (
+//
+//          );
+//    }
+//};
 
 /**
  * @brief Structure that contains decoded point in time.
@@ -37,18 +56,12 @@ typedef struct
  * The point with zero time (beginning of time) is considered to be
  * beginning of the mission itself.
  */
-typedef struct
-{
-    uint64_t value; ///< Time span length in milliseconds.
-} TimeSpan;
+typedef std::chrono::duration<uint64_t, std::milli> TimeSpan;
 
 /**
  * @brief Type used to represents different between two time spans.
  */
-typedef struct
-{
-    int64_t value; ///< Time shift length in milliseconds.
-} TimeShift;
+typedef std::chrono::duration<uint64_t, std::milli> TimeShift;
 
 /**
  * @brief Creates TimeSpan object initialized from time specified in milliseconds.
@@ -220,17 +233,17 @@ static inline bool TimePointLessThan(TimePoint left, TimePoint right)
 
 static inline bool TimeSpanEqual(const TimeSpan left, const TimeSpan right)
 {
-    return left.value == right.value;
+    return left == right;
 }
 
 static inline bool TimeSpanNotEqual(const TimeSpan left, const TimeSpan right)
 {
-    return left.value != right.value;
+    return left != right;
 }
 
 static inline bool TimeSpanLessThan(const TimeSpan left, const TimeSpan right)
 {
-    return left.value < right.value;
+    return left < right;
 }
 
 /** @} */

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -57,7 +57,7 @@ TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t sec
  * @param[in] span Time span to convert.
  * @return Decoded time point object.
  */
-TimePoint TimePointFromTimeSpan(std::chrono::milliseconds span);
+TimePoint TimePointFromDuration(std::chrono::milliseconds span);
 
 /**
  * @brief This procedure converts decoded time point object into time span value.

--- a/libs/time/include/time/TimePoint.h
+++ b/libs/time/include/time/TimePoint.h
@@ -33,47 +33,11 @@ typedef struct
 } TimePoint;
 
 /**
- * @brief Type used to measure current mission time in milliseconds.
- *
- * The point with zero time (beginning of time) is considered to be
- * beginning of the mission itself.
- */
-typedef std::chrono::milliseconds TimeSpan;
-
-/**
- * @brief Creates TimeSpan object initialized from time specified in milliseconds.
- * @param[in] milliseconds TimeSpan value in milliseconds.
- * @return Prepared time span object.
- */
-TimeSpan TimeSpanFromMilliseconds(uint64_t milliseconds);
-
-/**
- * @brief Creates TimeSpan object initialized from time specified in seconds.
- * @param[in] seconds TimeSpan value in seconds.
- * @return Prepared time span object.
- */
-TimeSpan TimeSpanFromSeconds(uint32_t seconds);
-
-/**
- * @brief Creates TimeSpan object initialized from time specified in minutes.
- * @param[in] minutes TimeSpan value in minutes.
- * @return Prepared time span object.
- */
-TimeSpan TimeSpanFromMinutes(uint32_t minutes);
-
-/**
- * @brief Creates TimeSpan object initialized from time specified in hours.
- * @param[in] hours TimeSpan value in hours.
- * @return Prepared time span object.
- */
-TimeSpan TimeSpanFromHours(uint32_t hours);
-
-/**
  * @brief Creates TimeSpan object initialized from time specified in days.
  * @param[in] days TimeSpan value in days.
  * @return Prepared time span object.
  */
-TimeSpan TimeSpanFromDays(uint32_t days);
+std::chrono::milliseconds TimeSpanFromDays(uint32_t days);
 
 /**
  * @brief This procedure builds Time point object.
@@ -93,22 +57,14 @@ TimePoint TimePointBuild(uint16_t day, uint8_t hour, uint8_t minute, uint8_t sec
  * @param[in] span Time span to convert.
  * @return Decoded time point object.
  */
-TimePoint TimePointFromTimeSpan(TimeSpan span);
+TimePoint TimePointFromTimeSpan(std::chrono::milliseconds span);
 
 /**
  * @brief This procedure converts decoded time point object into time span value.
  * @param[in] point Time point object to convert.
  * @return Converted time span value.
  */
-TimeSpan TimePointToTimeSpan(TimePoint point);
-
-/**
- * @brief This procedure converts passed timespan value to time span that is
- * measured in seconds.
- * @param[in] span Time span to convert.
- * @return Time span in seconds.
- */
-uint32_t TimeSpanToSeconds(TimeSpan span);
+std::chrono::milliseconds TimePointToTimeSpan(TimePoint point);
 
 /**
  * @brief This procedure normalizes TimePoint object.

--- a/libs/time/include/time/timer.h
+++ b/libs/time/include/time/timer.h
@@ -68,6 +68,10 @@ namespace services
              */
             TimeSpan CurrentTime;
 
+            TimeSnapshot() : CurrentTime(0ull)
+            {
+            }
+
             bool operator==(const TimeSnapshot& right) const
             {
                 return TimeSpanEqual(CurrentTime, right.CurrentTime);

--- a/libs/time/include/time/timer.h
+++ b/libs/time/include/time/timer.h
@@ -44,7 +44,7 @@ namespace services
             /**
              * @brief Current mission time in milliseconds.
              */
-            TimeSpan time;
+            std::chrono::milliseconds time;
 
             /**
              * @brief Flag indicating whether the timer state should be immediately saved.
@@ -66,7 +66,7 @@ namespace services
             /**
              * @brief Current mission time in milliseconds.
              */
-            TimeSpan CurrentTime;
+            std::chrono::milliseconds CurrentTime;
 
             TimeSnapshot() : CurrentTime(0ull)
             {
@@ -147,7 +147,7 @@ namespace services
              *
              * @return Option containing current mission time on success, empty option otherwise.
              */
-            Option<TimeSpan> GetCurrentTime();
+            Option<std::chrono::milliseconds> GetCurrentTime();
 
             /**
              * @brief This procedure returns current mission time in decoded format.
@@ -163,7 +163,7 @@ namespace services
              * timer state save process therefore the procedure may be take some time to complete.
              * @param[in] delta The amount of time that timer state should be moved forward.
              */
-            void AdvanceTime(TimeSpan delta);
+            void AdvanceTime(std::chrono::milliseconds delta);
 
             /**
              * @brief This procedure sets the current mission time to any arbitrary point in time.
@@ -196,7 +196,7 @@ namespace services
              * @param[in] delay Time span to wait
              * @return True if expected time span is elapsed, false in case of error
              */
-            bool LongDelay(TimeSpan delay);
+            bool LongDelay(std::chrono::milliseconds delay);
 
           public:
             /**
@@ -227,7 +227,7 @@ namespace services
              *
              * This value is protected by the timerLock semaphore.
              */
-            TimeSpan CurrentTime;
+            std::chrono::milliseconds CurrentTime;
 
           private:
             /**
@@ -310,7 +310,7 @@ namespace services
              * This value is used to determine whether the time notification should be invoked on next rtc notification.
              * This value is protected by the timerLock semaphore.
              */
-            TimeSpan NotificationTime;
+            std::chrono::milliseconds NotificationTime;
 
             /**
              * @brief Time period since the last timer state save.
@@ -318,7 +318,7 @@ namespace services
              * This value is used to determine whether the time state should be saved on next rtc notification.
              * This value is protected by the timerLock semaphore.
              */
-            TimeSpan PersistanceTime;
+            std::chrono::milliseconds PersistanceTime;
 
             /**
              * @brief Pulse notified on each timer tick

--- a/libs/time/include/time/timer.h
+++ b/libs/time/include/time/timer.h
@@ -74,7 +74,7 @@ namespace services
 
             bool operator==(const TimeSnapshot& right) const
             {
-                return TimeSpanEqual(CurrentTime, right.CurrentTime);
+                return CurrentTime == right.CurrentTime;
             }
 
             bool operator!=(const TimeSnapshot& right) const
@@ -84,7 +84,7 @@ namespace services
 
             bool operator<(const TimeSnapshot& right) const
             {
-                return TimeSpanLessThan(CurrentTime, right.CurrentTime);
+                return CurrentTime < right.CurrentTime;
             }
 
             bool operator>(const TimeSnapshot& right) const

--- a/libs/time/timer.cpp
+++ b/libs/time/timer.cpp
@@ -172,7 +172,7 @@ struct TimeSnapshot TimeProvider::ReadFile(IFileSystem& fs, const char* const fi
     }
 
     Reader reader(buffer);
-    result.CurrentTime = TimeSpan(reader.ReadQuadWordLE());
+    result.CurrentTime = TimeSpanFromMilliseconds(reader.ReadQuadWordLE());
     if (!reader.Status())
     {
         LOGF(LOG_LEVEL_WARNING, "Not enough data read from file: %s. ", filePath);

--- a/libs/time/timer.cpp
+++ b/libs/time/timer.cpp
@@ -67,7 +67,7 @@ bool TimeProvider::Initialize(TimePassedCallbackType timePassedCallback, void* t
 
 void TimeProvider::AdvanceTime(TimeSpan delta)
 {
-    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, MAX_DELAY)))
+    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, OSTaskTimeSpan(MAX_DELAY))))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to acquire timer lock.");
         return;
@@ -86,7 +86,7 @@ void TimeProvider::AdvanceTime(TimeSpan delta)
 bool TimeProvider::SetCurrentTime(TimePoint pointInTime)
 {
     const TimeSpan span = TimePointToTimeSpan(pointInTime);
-    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, MAX_DELAY)))
+    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, OSTaskTimeSpan(MAX_DELAY))))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to acquire timer lock.");
         return false;
@@ -104,7 +104,7 @@ bool TimeProvider::SetCurrentTime(TimePoint pointInTime)
 
 Option<TimeSpan> TimeProvider::GetCurrentTime()
 {
-    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, MAX_DELAY)))
+    if (OS_RESULT_FAILED(System::TakeSemaphore(timerLock, OSTaskTimeSpan(MAX_DELAY))))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to acquire timer lock.");
         return None<TimeSpan>();
@@ -129,7 +129,7 @@ Option<TimePoint> TimeProvider::GetCurrentMissionTime()
 
 void TimeProvider::ProcessChange(TimerState state)
 {
-    if (OS_RESULT_FAILED(System::TakeSemaphore(notificationLock, MAX_DELAY)))
+    if (OS_RESULT_FAILED(System::TakeSemaphore(notificationLock, OSTaskTimeSpan(MAX_DELAY))))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to acquire notification lock.");
         return;
@@ -324,7 +324,7 @@ bool TimeProvider::LongDelayUntil(TimePoint time)
             return true;
         }
 
-        if (OS_RESULT_FAILED(System::PulseWait(TickNotification, MAX_DELAY)))
+        if (OS_RESULT_FAILED(System::PulseWait(TickNotification, OSTaskTimeSpan(MAX_DELAY))))
         {
             return false;
         }

--- a/libs/yaffs_glue/yaffs_os_glue.cpp
+++ b/libs/yaffs_glue/yaffs_os_glue.cpp
@@ -19,7 +19,7 @@ extern "C" {
 
 void yaffsfs_Lock(void)
 {
-    System::TakeSemaphore(yaffsLock, MAX_DELAY);
+    System::TakeSemaphore(yaffsLock, OSTaskTimeSpan(MAX_DELAY));
 }
 
 void yaffsfs_Unlock(void)

--- a/libs/yaffs_glue/yaffs_os_glue.cpp
+++ b/libs/yaffs_glue/yaffs_os_glue.cpp
@@ -19,7 +19,7 @@ extern "C" {
 
 void yaffsfs_Lock(void)
 {
-    System::TakeSemaphore(yaffsLock, std::chrono::milliseconds(MAX_DELAY));
+    System::TakeSemaphore(yaffsLock, InfiniteTimeout);
 }
 
 void yaffsfs_Unlock(void)

--- a/libs/yaffs_glue/yaffs_os_glue.cpp
+++ b/libs/yaffs_glue/yaffs_os_glue.cpp
@@ -19,7 +19,7 @@ extern "C" {
 
 void yaffsfs_Lock(void)
 {
-    System::TakeSemaphore(yaffsLock, OSTaskTimeSpan(MAX_DELAY));
+    System::TakeSemaphore(yaffsLock, std::chrono::milliseconds(MAX_DELAY));
 }
 
 void yaffsfs_Unlock(void)

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -5,6 +5,8 @@
 #include "terminal.h"
 #include "utils.h"
 
+using namespace std::chrono_literals;
+
 static void SendResult(OSResult result)
 {
     Main.terminal.Printf("%d", result);
@@ -76,7 +78,7 @@ void AntennaDeploy(uint16_t argc, char* argv[])
     const OSResult result = Main.antennaDriver.DeployAntenna(&Main.antennaDriver,
         channel,
         antenna,
-        std::chrono::seconds(10),
+        10s,
         override //
         );
     SendResult(result);

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -76,7 +76,7 @@ void AntennaDeploy(uint16_t argc, char* argv[])
     const OSResult result = Main.antennaDriver.DeployAntenna(&Main.antennaDriver,
         channel,
         antenna,
-        TimeSpanFromSeconds(10),
+        std::chrono::seconds(10),
         override //
         );
     SendResult(result);

--- a/src/commands/time.cpp
+++ b/src/commands/time.cpp
@@ -15,7 +15,9 @@ void JumpToTimeHandler(uint16_t argc, char* argv[])
 
     char* tail;
     const TimeSpan targetTime = TimeSpanFromSeconds(strtoul(argv[0], &tail, 10));
-    LOGF(LOG_LEVEL_INFO, "Jumping to time %lu\n", static_cast<std::uint32_t>(targetTime.count() / 1000));
+    LOGF(LOG_LEVEL_INFO,
+        "Jumping to time %lu\n",
+        static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(targetTime).count()));
     Main.timeProvider.SetCurrentTime(TimePointFromTimeSpan(targetTime));
 }
 
@@ -29,7 +31,9 @@ void AdvanceTimeHandler(uint16_t argc, char* argv[])
 
     char* tail;
     const TimeSpan targetTime = TimeSpanFromMilliseconds(strtoul(argv[0], &tail, 10));
-    LOGF(LOG_LEVEL_INFO, "Advancing time by '%lu' seconds\n", static_cast<std::uint32_t>(targetTime.count() / 1000));
+    LOGF(LOG_LEVEL_INFO,
+        "Advancing time by '%lu' seconds\n",
+        static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(targetTime).count()));
     Main.timeProvider.AdvanceTime(targetTime);
 }
 
@@ -38,5 +42,5 @@ void CurrentTimeHandler(uint16_t argc, char* argv[])
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
     TimeSpan span = Main.timeProvider.GetCurrentTime().Value;
-    Main.terminal.Printf("%lu", static_cast<std::uint32_t>(span.count() / 1000));
+    Main.terminal.Printf("%lu", static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(span).count()));
 }

--- a/src/commands/time.cpp
+++ b/src/commands/time.cpp
@@ -14,10 +14,8 @@ void JumpToTimeHandler(uint16_t argc, char* argv[])
     }
 
     char* tail;
-    const TimeSpan targetTime = TimeSpanFromSeconds(strtoul(argv[0], &tail, 10));
-    LOGF(LOG_LEVEL_INFO,
-        "Jumping to time %lu\n",
-        static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(targetTime).count()));
+    const std::chrono::seconds targetTime = std::chrono::seconds(strtoul(argv[0], &tail, 10));
+    LOGF(LOG_LEVEL_INFO, "Jumping to time %lu\n", static_cast<std::uint32_t>(targetTime.count()));
     Main.timeProvider.SetCurrentTime(TimePointFromTimeSpan(targetTime));
 }
 
@@ -30,7 +28,7 @@ void AdvanceTimeHandler(uint16_t argc, char* argv[])
     }
 
     char* tail;
-    const TimeSpan targetTime = TimeSpanFromMilliseconds(strtoul(argv[0], &tail, 10));
+    const std::chrono::milliseconds targetTime = std::chrono::milliseconds(strtoul(argv[0], &tail, 10));
     LOGF(LOG_LEVEL_INFO,
         "Advancing time by '%lu' seconds\n",
         static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(targetTime).count()));
@@ -41,6 +39,6 @@ void CurrentTimeHandler(uint16_t argc, char* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
-    TimeSpan span = Main.timeProvider.GetCurrentTime().Value;
+    std::chrono::milliseconds span = Main.timeProvider.GetCurrentTime().Value;
     Main.terminal.Printf("%lu", static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(span).count()));
 }

--- a/src/commands/time.cpp
+++ b/src/commands/time.cpp
@@ -15,7 +15,7 @@ void JumpToTimeHandler(uint16_t argc, char* argv[])
 
     char* tail;
     const TimeSpan targetTime = TimeSpanFromSeconds(strtoul(argv[0], &tail, 10));
-    LOGF(LOG_LEVEL_INFO, "Jumping to time %lu\n", static_cast<std::uint32_t>(targetTime.value / 1000));
+    LOGF(LOG_LEVEL_INFO, "Jumping to time %lu\n", static_cast<std::uint32_t>(targetTime.count() / 1000));
     Main.timeProvider.SetCurrentTime(TimePointFromTimeSpan(targetTime));
 }
 
@@ -29,7 +29,7 @@ void AdvanceTimeHandler(uint16_t argc, char* argv[])
 
     char* tail;
     const TimeSpan targetTime = TimeSpanFromMilliseconds(strtoul(argv[0], &tail, 10));
-    LOGF(LOG_LEVEL_INFO, "Advancing time by '%lu' seconds\n", static_cast<std::uint32_t>(targetTime.value / 1000));
+    LOGF(LOG_LEVEL_INFO, "Advancing time by '%lu' seconds\n", static_cast<std::uint32_t>(targetTime.count() / 1000));
     Main.timeProvider.AdvanceTime(targetTime);
 }
 
@@ -38,5 +38,5 @@ void CurrentTimeHandler(uint16_t argc, char* argv[])
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
     TimeSpan span = Main.timeProvider.GetCurrentTime().Value;
-    Main.terminal.Printf("%lu", static_cast<std::uint32_t>(span.value / 1000));
+    Main.terminal.Printf("%lu", static_cast<std::uint32_t>(span.count() / 1000));
 }

--- a/src/commands/time.cpp
+++ b/src/commands/time.cpp
@@ -16,7 +16,7 @@ void JumpToTimeHandler(uint16_t argc, char* argv[])
     char* tail;
     const std::chrono::seconds targetTime = std::chrono::seconds(strtoul(argv[0], &tail, 10));
     LOGF(LOG_LEVEL_INFO, "Jumping to time %lu\n", static_cast<std::uint32_t>(targetTime.count()));
-    Main.timeProvider.SetCurrentTime(TimePointFromTimeSpan(targetTime));
+    Main.timeProvider.SetCurrentTime(TimePointFromDuration(targetTime));
 }
 
 void AdvanceTimeHandler(uint16_t argc, char* argv[])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "power_eps/power_eps.h"
 
 using services::time::TimeProvider;
+using namespace std::chrono_literals;
 
 OBC Main;
 mission::ObcMission Mission(Main.timeProvider, Main.antennaDriver, false);
@@ -84,7 +85,7 @@ static void SmartWaitTask(void* param)
 
     while (1)
     {
-        Main.timeProvider.LongDelay(std::chrono::minutes(10));
+        Main.timeProvider.LongDelay(10min);
         LOG(LOG_LEVEL_DEBUG, "After wait");
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,6 @@
 #include "terminal.h"
 
 #include "gpio/gpio.h"
-#include <chrono>
 #include "leuart/leuart.h"
 #include "power_eps/power_eps.h"
 
@@ -74,10 +73,6 @@ static void BlinkLed0(void* param)
     {
         Main.Hardware.Pins.Led0.Toggle();
         vTaskDelay(1000 / portTICK_PERIOD_MS);
-
-        std::chrono::milliseconds ms(10);
-
-        LOGF(LOG_LEVEL_INFO, "Blink %d", (int)ms.count());
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include "terminal.h"
 
 #include "gpio/gpio.h"
+#include <chrono>
 #include "leuart/leuart.h"
 #include "power_eps/power_eps.h"
 
@@ -73,6 +74,10 @@ static void BlinkLed0(void* param)
     {
         Main.Hardware.Pins.Led0.Toggle();
         vTaskDelay(1000 / portTICK_PERIOD_MS);
+
+        std::chrono::milliseconds ms(10);
+
+        LOGF(LOG_LEVEL_INFO, "Blink %d", (int)ms.count());
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ static void SmartWaitTask(void* param)
 
     while (1)
     {
-        Main.timeProvider.LongDelay(TimeSpanFromMinutes(10));
+        Main.timeProvider.LongDelay(std::chrono::minutes(10));
         LOG(LOG_LEVEL_DEBUG, "After wait");
     }
 }

--- a/test/flash/main.cpp
+++ b/test/flash/main.cpp
@@ -18,6 +18,8 @@
 #include "swo/swo.h"
 #include "system.h"
 
+using namespace std::chrono_literals;
+
 const int __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
 
 extern "C" void vApplicationStackOverflowHook(xTaskHandle* pxTask, signed char* pcTaskName)
@@ -146,7 +148,7 @@ static void Ping(void* v)
         GPIO_PinOutToggle(io_map::Led0::Port, io_map::Led0::PinNumber);
         GPIO_PinOutToggle(io_map::Led1::Port, io_map::Led1::PinNumber);
 
-        System::SleepTask(std::chrono::seconds(1));
+        System::SleepTask(1s);
     }
 }
 

--- a/test/flash/main.cpp
+++ b/test/flash/main.cpp
@@ -146,7 +146,7 @@ static void Ping(void* v)
         GPIO_PinOutToggle(io_map::Led0::Port, io_map::Led0::PinNumber);
         GPIO_PinOutToggle(io_map::Led1::Port, io_map::Led1::PinNumber);
 
-        System::SleepTask(1000);
+        System::SleepTask(OSTaskTimeSpan(1000));
     }
 }
 

--- a/test/flash/main.cpp
+++ b/test/flash/main.cpp
@@ -146,7 +146,7 @@ static void Ping(void* v)
         GPIO_PinOutToggle(io_map::Led0::Port, io_map::Led0::PinNumber);
         GPIO_PinOutToggle(io_map::Led1::Port, io_map::Led1::PinNumber);
 
-        System::SleepTask(OSTaskTimeSpan(1000));
+        System::SleepTask(std::chrono::seconds(1));
     }
 }
 

--- a/test/pulse_all/main.cpp
+++ b/test/pulse_all/main.cpp
@@ -58,7 +58,7 @@ static void Observer(void* param)
 
     for (;;)
     {
-        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, OSTaskTimeSpan(MAX_DELAY));
+        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, std::chrono::milliseconds(MAX_DELAY));
         LOGF(LOG_LEVEL_INFO, "Received notification with following bits: %ld", bits);
     }
 }

--- a/test/pulse_all/main.cpp
+++ b/test/pulse_all/main.cpp
@@ -58,7 +58,7 @@ static void Observer(void* param)
 
     for (;;)
     {
-        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, MAX_DELAY);
+        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, OSTaskTimeSpan(MAX_DELAY));
         LOGF(LOG_LEVEL_INFO, "Received notification with following bits: %ld", bits);
     }
 }

--- a/test/pulse_all/main.cpp
+++ b/test/pulse_all/main.cpp
@@ -58,7 +58,7 @@ static void Observer(void* param)
 
     for (;;)
     {
-        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, std::chrono::milliseconds(MAX_DELAY));
+        OSEventBits bits = System::EventGroupWaitForBits(groupHandle, 0x80, true, true, InfiniteTimeout);
         LOGF(LOG_LEVEL_INFO, "Received notification with following bits: %ld", bits);
     }
 }

--- a/unit_tests/MissionPlan/MissionPlanTest.cpp
+++ b/unit_tests/MissionPlan/MissionPlanTest.cpp
@@ -13,6 +13,7 @@ using testing::_;
 using testing::Invoke;
 using testing::Return;
 using namespace mission;
+using namespace std::chrono_literals;
 
 struct MissionPlanTest : public testing::Test
 {
@@ -41,7 +42,7 @@ TEST_F(MissionPlanTest, ShouldUpdateStateAccordingToDescriptors)
     }));
 
     EXPECT_CALL(update2, UpdateProc(_)).WillOnce(Invoke([](SystemState& state) {
-        state.Time = std::chrono::milliseconds(100);
+        state.Time = 100ms;
         return UpdateResult::Ok;
     }));
 
@@ -50,7 +51,7 @@ TEST_F(MissionPlanTest, ShouldUpdateStateAccordingToDescriptors)
     const auto result = SystemStateUpdate(state, gsl::make_span(stateDescriptors));
 
     ASSERT_THAT(state.SailOpened, Eq(true));
-    ASSERT_THAT(state.Time, Eq(std::chrono::milliseconds(100)));
+    ASSERT_THAT(state.Time, Eq(100ms));
     ASSERT_THAT(result, Eq(UpdateResult::Ok));
 }
 

--- a/unit_tests/MissionPlan/MissionPlanTest.cpp
+++ b/unit_tests/MissionPlan/MissionPlanTest.cpp
@@ -41,7 +41,7 @@ TEST_F(MissionPlanTest, ShouldUpdateStateAccordingToDescriptors)
     }));
 
     EXPECT_CALL(update2, UpdateProc(_)).WillOnce(Invoke([](SystemState& state) {
-        state.Time = TimeSpanFromMilliseconds(100);
+        state.Time = std::chrono::milliseconds(100);
         return UpdateResult::Ok;
     }));
 
@@ -50,7 +50,7 @@ TEST_F(MissionPlanTest, ShouldUpdateStateAccordingToDescriptors)
     const auto result = SystemStateUpdate(state, gsl::make_span(stateDescriptors));
 
     ASSERT_THAT(state.SailOpened, Eq(true));
-    ASSERT_THAT(state.Time, Eq(TimeSpanFromMilliseconds(100)));
+    ASSERT_THAT(state.Time, Eq(std::chrono::milliseconds(100)));
     ASSERT_THAT(result, Eq(UpdateResult::Ok));
 }
 

--- a/unit_tests/MissionPlan/MissionPlanTest.cpp
+++ b/unit_tests/MissionPlan/MissionPlanTest.cpp
@@ -28,7 +28,7 @@ MissionPlanTest::MissionPlanTest()
 TEST_F(MissionPlanTest, EmptyStateShouldHaveEmptyValues)
 {
     ASSERT_THAT(state.SailOpened, Eq(false));
-    ASSERT_THAT(state.Time.value, Eq(0ul));
+    ASSERT_THAT(state.Time.count(), Eq(0ul));
     ASSERT_THAT(state.Antenna.Deployed, Eq(false));
 }
 

--- a/unit_tests/MissionPlan/MissionTestHelpers.cpp
+++ b/unit_tests/MissionPlan/MissionTestHelpers.cpp
@@ -4,6 +4,6 @@
 
 void showValue(const SystemState& state, std::ostream& os)
 {
-    os << "time=" << state.Time.value << ", "
+    os << "time=" << state.Time.count() << ", "
        << "antennaDeployed=" << state.Antenna.Deployed;
 }

--- a/unit_tests/MissionPlan/MissionTestHelpers.h
+++ b/unit_tests/MissionPlan/MissionTestHelpers.h
@@ -7,28 +7,6 @@
 
 namespace rc
 {
-    template <> struct Arbitrary<std::chrono::milliseconds>
-    {
-        static Gen<std::chrono::milliseconds> arbitrary()
-        {
-            auto day = gen::nonNegative<uint16_t>();
-            auto hour = gen::inRange(0, 23);
-            auto minute = gen::inRange(0, 59);
-            auto second = gen::inRange(0, 59);
-            auto milisecond = gen::inRange(0, 999);
-
-            return gen::apply(
-                [](uint16_t day, uint16_t hour, uint16_t minute, uint16_t second, uint16_t milisecond) {
-                    return TimePointToTimeSpan(TimePointBuild(day, hour, minute, second, milisecond));
-                },
-                day,
-                hour,
-                minute,
-                second,
-                milisecond);
-        }
-    };
-
     template <> struct Arbitrary<SystemState>
     {
         static Gen<SystemState> arbitrary()

--- a/unit_tests/MissionPlan/MissionTestHelpers.h
+++ b/unit_tests/MissionPlan/MissionTestHelpers.h
@@ -7,9 +7,9 @@
 
 namespace rc
 {
-    template <> struct Arbitrary<TimeSpan>
+    template <> struct Arbitrary<std::chrono::milliseconds>
     {
-        static Gen<TimeSpan> arbitrary()
+        static Gen<std::chrono::milliseconds> arbitrary()
         {
             auto day = gen::nonNegative<uint16_t>();
             auto hour = gen::inRange(0, 23);
@@ -33,9 +33,9 @@ namespace rc
     {
         static Gen<SystemState> arbitrary()
         {
-            return gen::build<SystemState>(                                //
-                gen::set(&SystemState::Time, gen::arbitrary<TimeSpan>()),  //
-                gen::set(&SystemState::SailOpened, gen::arbitrary<bool>()) //
+            return gen::build<SystemState>(                                                //
+                gen::set(&SystemState::Time, gen::arbitrary<std::chrono::milliseconds>()), //
+                gen::set(&SystemState::SailOpened, gen::arbitrary<bool>())                 //
                 );
         }
     };

--- a/unit_tests/MissionPlan/SailSystemStateTest.cpp
+++ b/unit_tests/MissionPlan/SailSystemStateTest.cpp
@@ -13,6 +13,7 @@
 using testing::Eq;
 using testing::Gt;
 using namespace mission;
+using namespace std::chrono_literals;
 
 struct SailSystemStateTest : public testing::Test
 {
@@ -67,7 +68,7 @@ TEST_F(SailSystemStateTest, ShouldUpdateSystemState)
 
 TEST_F(SailSystemStateTest, ShouldOpenSailAfterTimeIfNotOpened)
 {
-    state.Time = std::chrono::hours(40) + std::chrono::seconds(1);
+    state.Time = 40h + 1s;
     state.SailOpened = false;
 
     DetermineActions();
@@ -84,6 +85,6 @@ RC_GTEST_FIXTURE_PROP(SailSystemStateTest, SailCannotBeOpenedIfNotPossible, (con
     if (runnable)
     {
         RC_ASSERT(this->state.SailOpened == false);
-        RC_ASSERT(std::chrono::hours(40) < this->state.Time);
+        RC_ASSERT(40h < this->state.Time);
     }
 }

--- a/unit_tests/MissionPlan/SailSystemStateTest.cpp
+++ b/unit_tests/MissionPlan/SailSystemStateTest.cpp
@@ -67,7 +67,7 @@ TEST_F(SailSystemStateTest, ShouldUpdateSystemState)
 
 TEST_F(SailSystemStateTest, ShouldOpenSailAfterTimeIfNotOpened)
 {
-    state.Time = TimeSpanAdd(TimeSpanFromHours(40), TimeSpanFromSeconds(1));
+    state.Time = TimeSpanFromHours(40) + TimeSpanFromSeconds(1);
     state.SailOpened = false;
 
     DetermineActions();

--- a/unit_tests/MissionPlan/SailSystemStateTest.cpp
+++ b/unit_tests/MissionPlan/SailSystemStateTest.cpp
@@ -67,7 +67,7 @@ TEST_F(SailSystemStateTest, ShouldUpdateSystemState)
 
 TEST_F(SailSystemStateTest, ShouldOpenSailAfterTimeIfNotOpened)
 {
-    state.Time = TimeSpanFromHours(40) + TimeSpanFromSeconds(1);
+    state.Time = std::chrono::hours(40) + std::chrono::seconds(1);
     state.SailOpened = false;
 
     DetermineActions();
@@ -84,6 +84,6 @@ RC_GTEST_FIXTURE_PROP(SailSystemStateTest, SailCannotBeOpenedIfNotPossible, (con
     if (runnable)
     {
         RC_ASSERT(this->state.SailOpened == false);
-        RC_ASSERT(TimeSpanFromHours(40) < this->state.Time);
+        RC_ASSERT(std::chrono::hours(40) < this->state.Time);
     }
 }

--- a/unit_tests/MissionPlan/TimeTaskTest.cpp
+++ b/unit_tests/MissionPlan/TimeTaskTest.cpp
@@ -12,7 +12,7 @@ using testing::Ne;
 using testing::Return;
 using testing::_;
 using namespace mission;
-using std::chrono::seconds;
+using namespace std::chrono_literals;
 
 struct TimeTaskTest : public testing::Test
 {
@@ -36,21 +36,21 @@ TimeTaskTest::TimeTaskTest() : provider(fileSystemMock), sailTask(provider), upd
 TEST_F(TimeTaskTest, TestTimeUpdate)
 {
     auto proxy = InstallProxy(&mock);
-    provider.SetCurrentTime(TimePointFromTimeSpan(seconds(12345678)));
+    provider.SetCurrentTime(TimePointFromDuration(12345678s));
 
     EXPECT_CALL(mock, TakeSemaphore(_, _)).WillOnce(Return(OSResult::Success));
     const auto result = updateDescriptor.updateProc(state, updateDescriptor.param);
     ASSERT_THAT(result, Eq(UpdateResult::Ok));
-    ASSERT_THAT(state.Time, Eq(seconds(12345678)));
+    ASSERT_THAT(state.Time, Eq(12345678s));
 }
 
 TEST_F(TimeTaskTest, TestTimeUpdateFailure)
 {
     auto proxy = InstallProxy(&mock);
-    provider.SetCurrentTime(TimePointFromTimeSpan(seconds(12345678)));
+    provider.SetCurrentTime(TimePointFromDuration(12345678s));
 
     EXPECT_CALL(mock, TakeSemaphore(_, _)).WillOnce(Return(OSResult::IOError));
     const auto result = updateDescriptor.updateProc(state, updateDescriptor.param);
     ASSERT_THAT(result, Eq(UpdateResult::Warning));
-    ASSERT_THAT(state.Time, Ne(seconds(12345678)));
+    ASSERT_THAT(state.Time, Ne(12345678s));
 }

--- a/unit_tests/MissionPlan/TimeTaskTest.cpp
+++ b/unit_tests/MissionPlan/TimeTaskTest.cpp
@@ -12,6 +12,7 @@ using testing::Ne;
 using testing::Return;
 using testing::_;
 using namespace mission;
+using std::chrono::seconds;
 
 struct TimeTaskTest : public testing::Test
 {
@@ -35,21 +36,21 @@ TimeTaskTest::TimeTaskTest() : provider(fileSystemMock), sailTask(provider), upd
 TEST_F(TimeTaskTest, TestTimeUpdate)
 {
     auto proxy = InstallProxy(&mock);
-    provider.SetCurrentTime(TimePointFromTimeSpan(TimeSpanFromSeconds(12345678)));
+    provider.SetCurrentTime(TimePointFromTimeSpan(seconds(12345678)));
 
     EXPECT_CALL(mock, TakeSemaphore(_, _)).WillOnce(Return(OSResult::Success));
     const auto result = updateDescriptor.updateProc(state, updateDescriptor.param);
     ASSERT_THAT(result, Eq(UpdateResult::Ok));
-    ASSERT_THAT(state.Time, Eq(TimeSpanFromSeconds(12345678)));
+    ASSERT_THAT(state.Time, Eq(seconds(12345678)));
 }
 
 TEST_F(TimeTaskTest, TestTimeUpdateFailure)
 {
     auto proxy = InstallProxy(&mock);
-    provider.SetCurrentTime(TimePointFromTimeSpan(TimeSpanFromSeconds(12345678)));
+    provider.SetCurrentTime(TimePointFromTimeSpan(seconds(12345678)));
 
     EXPECT_CALL(mock, TakeSemaphore(_, _)).WillOnce(Return(OSResult::IOError));
     const auto result = updateDescriptor.updateProc(state, updateDescriptor.param);
     ASSERT_THAT(result, Eq(UpdateResult::Warning));
-    ASSERT_THAT(state.Time, Ne(TimeSpanFromSeconds(12345678)));
+    ASSERT_THAT(state.Time, Ne(seconds(12345678)));
 }

--- a/unit_tests/MissionPlan/antenna/DeployAntennasTest.cpp
+++ b/unit_tests/MissionPlan/antenna/DeployAntennasTest.cpp
@@ -17,7 +17,7 @@ using testing::Invoke;
 using mission::antenna::AntennaMissionState;
 using mission::antenna::AntennaTask;
 using namespace mission;
-using std::chrono::minutes;
+using namespace std::chrono_literals;
 
 class DeployAntennasTest : public ::testing::Test
 {
@@ -40,33 +40,33 @@ DeployAntennasTest::DeployAntennasTest()
 
 TEST_F(DeployAntennasTest, TestConditionTimeBeforeThreshold)
 {
-    state.Time = minutes(31);
+    state.Time = 31min;
     ASSERT_FALSE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionTimeAfterThreshold)
 {
-    state.Time = minutes(41);
+    state.Time = 41min;
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionAntennasAreOpen)
 {
-    state.Time = minutes(41);
+    state.Time = 41min;
     stateDescriptor.OverrideStep(AntennaMissionState::StepCount());
     ASSERT_FALSE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionAntennasAreNotOpen)
 {
-    state.Time = minutes(41);
+    state.Time = 41min;
     stateDescriptor.OverrideStep(AntennaMissionState::StepCount() - 1);
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionDeploymentInProgress)
 {
-    state.Time = minutes(41);
+    state.Time = 41min;
     AntennaDeploymentStatus status = {};
     status.IsDeploymentActive[1] = true;
     stateDescriptor.Update(status);
@@ -75,7 +75,7 @@ TEST_F(DeployAntennasTest, TestConditionDeploymentInProgress)
 
 TEST_F(DeployAntennasTest, TestConditionOverrideDeploymentState)
 {
-    state.Time = minutes(41);
+    state.Time = 41min;
     state.Antenna.Deployed = true;
     stateDescriptor.OverrideState();
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));

--- a/unit_tests/MissionPlan/antenna/DeployAntennasTest.cpp
+++ b/unit_tests/MissionPlan/antenna/DeployAntennasTest.cpp
@@ -17,6 +17,7 @@ using testing::Invoke;
 using mission::antenna::AntennaMissionState;
 using mission::antenna::AntennaTask;
 using namespace mission;
+using std::chrono::minutes;
 
 class DeployAntennasTest : public ::testing::Test
 {
@@ -39,33 +40,33 @@ DeployAntennasTest::DeployAntennasTest()
 
 TEST_F(DeployAntennasTest, TestConditionTimeBeforeThreshold)
 {
-    state.Time = TimeSpanFromMinutes(31);
+    state.Time = minutes(31);
     ASSERT_FALSE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionTimeAfterThreshold)
 {
-    state.Time = TimeSpanFromMinutes(41);
+    state.Time = minutes(41);
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionAntennasAreOpen)
 {
-    state.Time = TimeSpanFromMinutes(41);
+    state.Time = minutes(41);
     stateDescriptor.OverrideStep(AntennaMissionState::StepCount());
     ASSERT_FALSE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionAntennasAreNotOpen)
 {
-    state.Time = TimeSpanFromMinutes(41);
+    state.Time = minutes(41);
     stateDescriptor.OverrideStep(AntennaMissionState::StepCount() - 1);
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));
 }
 
 TEST_F(DeployAntennasTest, TestConditionDeploymentInProgress)
 {
-    state.Time = TimeSpanFromMinutes(41);
+    state.Time = minutes(41);
     AntennaDeploymentStatus status = {};
     status.IsDeploymentActive[1] = true;
     stateDescriptor.Update(status);
@@ -74,7 +75,7 @@ TEST_F(DeployAntennasTest, TestConditionDeploymentInProgress)
 
 TEST_F(DeployAntennasTest, TestConditionOverrideDeploymentState)
 {
-    state.Time = TimeSpanFromMinutes(41);
+    state.Time = minutes(41);
     state.Antenna.Deployed = true;
     stateDescriptor.OverrideState();
     ASSERT_TRUE(openAntenna.condition(state, openAntenna.param));

--- a/unit_tests/N25Q/N25QTest.cpp
+++ b/unit_tests/N25Q/N25QTest.cpp
@@ -776,7 +776,7 @@ TEST_F(N25QDriverTest, SettingProtectionOnResetCanTimeout)
             ExpectCommand(Command::ResetMemory);
         }
 
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
         {
             auto selected = this->_spi.ExpectSelected();
@@ -800,15 +800,15 @@ TEST_F(N25QDriverTest, SettingProtectionOnResetCanTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::numeric_limits<uint32_t>::max()));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(std::numeric_limits<uint32_t>::max())));
         }
     }
 
@@ -834,20 +834,20 @@ TEST_F(N25QDriverTest, WaitingOnResetCanTimeout)
             ExpectCommand(Command::ResetMemory);
         }
 
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
         {
             auto selected = this->_spi.ExpectSelected();
 
             ExpectCommandAndRespondOnce(Command::ReadId, _incorrectId);
         }
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
         {
             auto selected = this->_spi.ExpectSelected();
 
             ExpectCommandAndRespondOnce(Command::ReadId, _incorrectId);
         }
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::numeric_limits<uint32_t>::max()));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(std::numeric_limits<uint32_t>::max())));
     }
 
     auto result = this->_driver.Reset();

--- a/unit_tests/N25Q/N25QTest.cpp
+++ b/unit_tests/N25Q/N25QTest.cpp
@@ -148,7 +148,7 @@ N25QDriverTest::N25QDriverTest() : _driver(_spi), _incorrectId{0xAA, 0xBB, 0xCC}
 {
     this->_osReset = InstallProxy(&this->_os);
 
-    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(OSTaskTimeSpan(0)));
+    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(std::chrono::milliseconds(0)));
 }
 
 TEST_F(N25QDriverTest, ShouldReadIdCorrectly)
@@ -463,15 +463,15 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSubsectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(std::numeric_limits<uint32_t>::max())));
         }
     }
 
@@ -580,15 +580,15 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(std::numeric_limits<uint32_t>::max())));
         }
     }
 
@@ -685,15 +685,15 @@ TEST_F(N25QDriverTest, EraseChipOperationWillTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(std::numeric_limits<uint32_t>::max())));
         }
     }
 

--- a/unit_tests/N25Q/N25QTest.cpp
+++ b/unit_tests/N25Q/N25QTest.cpp
@@ -148,7 +148,7 @@ N25QDriverTest::N25QDriverTest() : _driver(_spi), _incorrectId{0xAA, 0xBB, 0xCC}
 {
     this->_osReset = InstallProxy(&this->_os);
 
-    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(0));
+    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(OSTaskTimeSpan(0)));
 }
 
 TEST_F(N25QDriverTest, ShouldReadIdCorrectly)
@@ -463,15 +463,15 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSubsectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::numeric_limits<uint32_t>::max()));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
         }
     }
 
@@ -580,15 +580,15 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::numeric_limits<uint32_t>::max()));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
         }
     }
 
@@ -685,15 +685,15 @@ TEST_F(N25QDriverTest, EraseChipOperationWillTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::numeric_limits<uint32_t>::max()));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(std::numeric_limits<uint32_t>::max())));
         }
     }
 

--- a/unit_tests/N25Q/N25QTest.cpp
+++ b/unit_tests/N25Q/N25QTest.cpp
@@ -35,6 +35,7 @@ using testing::AtLeast;
 
 using drivers::spi::ISPIInterface;
 using namespace devices::n25q;
+using namespace std::chrono_literals;
 
 enum Command
 {
@@ -148,7 +149,7 @@ N25QDriverTest::N25QDriverTest() : _driver(_spi), _incorrectId{0xAA, 0xBB, 0xCC}
 {
     this->_osReset = InstallProxy(&this->_os);
 
-    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(std::chrono::milliseconds(0)));
+    ON_CALL(this->_os, GetUptime()).WillByDefault(Return(0ms));
 }
 
 TEST_F(N25QDriverTest, ShouldReadIdCorrectly)
@@ -463,11 +464,11 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSubsectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
@@ -580,11 +581,11 @@ TEST_F(N25QDriverTest, ShouldDetectEraseSectorTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
@@ -685,11 +686,11 @@ TEST_F(N25QDriverTest, EraseChipOperationWillTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
@@ -776,7 +777,7 @@ TEST_F(N25QDriverTest, SettingProtectionOnResetCanTimeout)
             ExpectCommand(Command::ResetMemory);
         }
 
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
         {
             auto selected = this->_spi.ExpectSelected();
@@ -800,11 +801,11 @@ TEST_F(N25QDriverTest, SettingProtectionOnResetCanTimeout)
         {
             auto selected = this->_spi.ExpectSelected();
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
-            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+            EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
             ExpectCommandAndRespondOnce(Command::ReadStatusRegister, Status::WriteEnabled | Status::WriteInProgress);
 
@@ -834,13 +835,13 @@ TEST_F(N25QDriverTest, WaitingOnResetCanTimeout)
             ExpectCommand(Command::ResetMemory);
         }
 
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
         {
             auto selected = this->_spi.ExpectSelected();
 
             ExpectCommandAndRespondOnce(Command::ReadId, _incorrectId);
         }
-        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+        EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
         {
             auto selected = this->_spi.ExpectSelected();

--- a/unit_tests/OsMock.hpp
+++ b/unit_tests/OsMock.hpp
@@ -22,11 +22,11 @@ struct OSMock : IOS
 
     MOCK_METHOD0(RunScheduller, void());
 
-    MOCK_METHOD1(Sleep, void(const OSTaskTimeSpan time));
+    MOCK_METHOD1(Sleep, void(const std::chrono::milliseconds time));
 
     MOCK_METHOD1(CreateBinarySemaphore, OSSemaphoreHandle(uint8_t semaphoreId));
 
-    MOCK_METHOD2(TakeSemaphore, OSResult(const OSSemaphoreHandle semaphore, const OSTaskTimeSpan time));
+    MOCK_METHOD2(TakeSemaphore, OSResult(const OSSemaphoreHandle semaphore, const std::chrono::milliseconds time));
 
     MOCK_METHOD1(GiveSemaphore, OSResult(const OSSemaphoreHandle semaphore));
 
@@ -37,29 +37,32 @@ struct OSMock : IOS
     MOCK_METHOD2(EventGroupClearBits, OSEventBits(OSEventGroupHandle eventGroup, const OSEventBits bitsToChange));
 
     MOCK_METHOD5(EventGroupWaitForBits,
-        OSEventBits(
-            OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const OSTaskTimeSpan timeout));
+        OSEventBits(OSEventGroupHandle eventGroup,
+            const OSEventBits bitsToWaitFor,
+            bool waitAll,
+            bool autoReset,
+            const std::chrono::milliseconds timeout));
 
     MOCK_METHOD2(EventGroupSetBitsISR, OSEventBits(OSEventGroupHandle eventGroup, const OSEventBits bitsToChange));
 
     MOCK_METHOD1(Alloc, void*(std::size_t size));
     MOCK_METHOD1(Free, void(void* ptr));
     MOCK_METHOD2(CreateQueue, OSQueueHandle(std::size_t maxElementCount, std::size_t elementSize));
-    MOCK_METHOD3(QueueReceive, bool(OSQueueHandle queue, void* element, OSTaskTimeSpan timeout));
+    MOCK_METHOD3(QueueReceive, bool(OSQueueHandle queue, void* element, std::chrono::milliseconds timeout));
     MOCK_METHOD2(QueueReceiveFromISR, bool(OSQueueHandle queue, void* element));
-    MOCK_METHOD3(QueueSend, bool(OSQueueHandle queue, const void* element, OSTaskTimeSpan timeout));
+    MOCK_METHOD3(QueueSend, bool(OSQueueHandle queue, const void* element, std::chrono::milliseconds timeout));
     MOCK_METHOD2(QueueSendISR, bool(OSQueueHandle queue, const void* element));
     MOCK_METHOD2(QueueOverwrite, void(OSQueueHandle queue, const void* element));
 
     MOCK_METHOD0(CreatePulseAll, OSPulseHandle());
 
-    MOCK_METHOD2(PulseWait, OSResult(OSPulseHandle handle, OSTaskTimeSpan timeout));
+    MOCK_METHOD2(PulseWait, OSResult(OSPulseHandle handle, std::chrono::milliseconds timeout));
 
     MOCK_METHOD1(PulseSet, void(OSPulseHandle handle));
 
     MOCK_METHOD0(EndSwitchingISR, void());
 
-    MOCK_METHOD0(GetUptime, OSTaskTimeSpan());
+    MOCK_METHOD0(GetUptime, std::chrono::milliseconds());
 
     MOCK_METHOD0(Yield, void());
 };

--- a/unit_tests/antenna/MiniportMock.cpp
+++ b/unit_tests/antenna/MiniportMock.cpp
@@ -33,7 +33,7 @@ static OSResult DeployAntenna(struct AntennaMiniportDriver* driver,
     II2CBus* /*communicationBus*/,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan timeout,
+    std::chrono::milliseconds timeout,
     bool override //
     )
 {
@@ -44,7 +44,7 @@ static OSResult DeployAntenna(struct AntennaMiniportDriver* driver,
 static OSResult InitializeAutomaticDeployment(struct AntennaMiniportDriver* driver,
     II2CBus* /*communicationBus*/,
     AntennaChannel channel,
-    TimeSpan timeout //
+    std::chrono::milliseconds timeout //
     )
 {
     auto mock = static_cast<AntennaMiniportMock*>(driver);
@@ -85,7 +85,7 @@ static OSResult GetAntennaActivationTime(struct AntennaMiniportDriver* driver,
     II2CBus* /*communicationBus*/,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan* count //
+    std::chrono::milliseconds* count //
     )
 {
     auto mock = static_cast<AntennaMiniportMock*>(driver);

--- a/unit_tests/antenna/MiniportMock.hpp
+++ b/unit_tests/antenna/MiniportMock.hpp
@@ -16,32 +16,32 @@ struct AntennaMiniportMock : AntennaMiniportDriver
 
     MOCK_METHOD1(DisarmDeploymentSystem, OSResult(AntennaChannel channel));
 
-    MOCK_METHOD2(InitializeAutomaticDeployment, OSResult(AntennaChannel channel, TimeSpan timeout));
+    MOCK_METHOD2(InitializeAutomaticDeployment, OSResult(AntennaChannel channel, std::chrono::milliseconds timeout));
 
     MOCK_METHOD1(CancelAntennaDeployment, OSResult(AntennaChannel channel));
 
     MOCK_METHOD4(DeployAntenna,
         OSResult(AntennaChannel channel,
-                     AntennaId antennaId,
-                     TimeSpan timeout,
-                     bool override //
-                     ));
+            AntennaId antennaId,
+            std::chrono::milliseconds timeout,
+            bool override //
+            ));
 
     MOCK_METHOD2(GetDeploymentStatus,
         OSResult(AntennaChannel channel,
-                     AntennaDeploymentStatus* telemetry //
-                     ));
+            AntennaDeploymentStatus* telemetry //
+            ));
 
     MOCK_METHOD3(GetAntennaActivationCount,
         OSResult(AntennaChannel channel,
-                     AntennaId antennaId,
-                     uint16_t* count //
-                     ));
+            AntennaId antennaId,
+            uint16_t* count //
+            ));
 
     MOCK_METHOD3(GetAntennaActivationTime,
         OSResult(AntennaChannel channel,
-                     AntennaId antennaId,
-                     TimeSpan* span) //
+            AntennaId antennaId,
+            std::chrono::milliseconds* span) //
         );
 
     MOCK_METHOD2(GetTemperature, OSResult(AntennaChannel channel, uint16_t* temperature));

--- a/unit_tests/antenna/antenna.cpp
+++ b/unit_tests/antenna/antenna.cpp
@@ -9,7 +9,7 @@ using testing::Ne;
 using testing::_;
 using testing::Return;
 using testing::Invoke;
-using std::chrono::seconds;
+using namespace std::chrono_literals;
 
 class AntennaDriverTest : public testing::Test
 {
@@ -173,19 +173,19 @@ TEST_F(AntennaDriverTest, TestGetTelemetryBothChannelsFailure)
 TEST_F(AntennaDriverTest, TestAutoDeployAntennaArmsDeploymentSystem)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).Times(1);
-    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA_AUTO_ID, seconds(10), false);
+    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA_AUTO_ID, 10s, false);
 }
 
 TEST_F(AntennaDriverTest, TestManualDeployAntennaArmsDeploymentSystem)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).Times(1);
-    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, seconds(10), false);
+    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, 10s, false);
 }
 
 TEST_F(AntennaDriverTest, TestDeployAntennaArmingFailure)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, seconds(10), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, 10s, false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -193,7 +193,7 @@ TEST_F(AntennaDriverTest, TestAutomaticDeploymentSuccess)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, InitializeAutomaticDeployment(ANTENNA_BACKUP_CHANNEL, _)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, seconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, 20s, false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
@@ -201,7 +201,7 @@ TEST_F(AntennaDriverTest, TestAutomaticDeploymentFailure)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, InitializeAutomaticDeployment(ANTENNA_BACKUP_CHANNEL, _)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, seconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, 20s, false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -209,7 +209,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentSuccess)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, false)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, 20s, false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
@@ -217,7 +217,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentFailure)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, false)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, 20s, false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -225,7 +225,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentSuccessWithOverride)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, true)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), true);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, 20s, true);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 

--- a/unit_tests/antenna/antenna.cpp
+++ b/unit_tests/antenna/antenna.cpp
@@ -9,6 +9,7 @@ using testing::Ne;
 using testing::_;
 using testing::Return;
 using testing::Invoke;
+using std::chrono::seconds;
 
 class AntennaDriverTest : public testing::Test
 {
@@ -172,19 +173,19 @@ TEST_F(AntennaDriverTest, TestGetTelemetryBothChannelsFailure)
 TEST_F(AntennaDriverTest, TestAutoDeployAntennaArmsDeploymentSystem)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).Times(1);
-    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA_AUTO_ID, TimeSpanFromSeconds(10), false);
+    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA_AUTO_ID, seconds(10), false);
 }
 
 TEST_F(AntennaDriverTest, TestManualDeployAntennaArmsDeploymentSystem)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).Times(1);
-    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(10), false);
+    driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, seconds(10), false);
 }
 
 TEST_F(AntennaDriverTest, TestDeployAntennaArmingFailure)
 {
     EXPECT_CALL(primary, ArmDeploymentSystem(ANTENNA_PRIMARY_CHANNEL)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(10), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_PRIMARY_CHANNEL, ANTENNA3_ID, seconds(10), false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -192,7 +193,7 @@ TEST_F(AntennaDriverTest, TestAutomaticDeploymentSuccess)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, InitializeAutomaticDeployment(ANTENNA_BACKUP_CHANNEL, _)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, TimeSpanFromSeconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, seconds(20), false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
@@ -200,7 +201,7 @@ TEST_F(AntennaDriverTest, TestAutomaticDeploymentFailure)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, InitializeAutomaticDeployment(ANTENNA_BACKUP_CHANNEL, _)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, TimeSpanFromSeconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA_AUTO_ID, seconds(20), false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -208,7 +209,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentSuccess)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, false)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
@@ -216,7 +217,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentFailure)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, false)).WillOnce(Return(OSResult::DeviceNotFound));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(20), false);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -224,7 +225,7 @@ TEST_F(AntennaDriverTest, TestManualDeploymentSuccessWithOverride)
 {
     ON_CALL(primary, ArmDeploymentSystem(_)).WillByDefault(Return(OSResult::Success));
     EXPECT_CALL(primary, DeployAntenna(ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, _, true)).WillOnce(Return(OSResult::Success));
-    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(20), true);
+    const auto status = driver.DeployAntenna(&driver, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(20), true);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 

--- a/unit_tests/antenna/miniport.cpp
+++ b/unit_tests/antenna/miniport.cpp
@@ -41,6 +41,8 @@ using testing::Invoke;
 using testing::ElementsAre;
 using gsl::span;
 using drivers::i2c::I2CResult;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
 
 class AntennaMiniportTest : public testing::Test
 {
@@ -100,14 +102,14 @@ TEST_F(AntennaMiniportTest, TestDisarmingDeploymentFailure)
 TEST_F(AntennaMiniportTest, TestAutomaticDeployment)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, BeginsWith(StartDeployment))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, TimeSpanFromSeconds(200));
+    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, seconds(200));
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestAutomaticDeploymentFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, BeginsWith(StartDeployment))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, TimeSpanFromSeconds(200));
+    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, seconds(200));
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -128,28 +130,28 @@ TEST_F(AntennaMiniportTest, TestCancelAutomaticDeploymentFailure)
 TEST_F(AntennaMiniportTest, TestManualAntennaDeployment)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna1, 200u))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, TimeSpanFromSeconds(200), false);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, seconds(200), false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna2, 200u))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, TimeSpanFromSeconds(200), false);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, seconds(200), false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentWithOverride)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna1Override, 200u))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, TimeSpanFromSeconds(200), true);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, seconds(200), true);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentWithOverrideFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_BACKUP_CHANNEL, ElementsAre(DeployAntenna3Override, 200u))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, TimeSpanFromSeconds(200), true);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(200), true);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -223,19 +225,19 @@ TEST_F(AntennaMiniportTest, TestAntennaActivationTime)
             outData[0] = 10;
             return I2CResult::OK;
         }));
-    TimeSpan response;
+    milliseconds response;
     const auto status = miniport.GetAntennaActivationTime(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, &response);
     ASSERT_THAT(status, Eq(OSResult::Success));
-    ASSERT_THAT(response, Eq(TimeSpanFromMilliseconds(128000)));
+    ASSERT_THAT(response, Eq(milliseconds(128000)));
 }
 
 TEST_F(AntennaMiniportTest, TestAntennaActivationTimeFailure)
 {
     EXPECT_CALL(i2c, WriteRead(ANTENNA_PRIMARY_CHANNEL, ElementsAre(QueryActivationTime2), _)).WillOnce(Return(I2CResult::Nack));
-    TimeSpan response;
+    milliseconds response;
     const auto status = miniport.GetAntennaActivationTime(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, &response);
     ASSERT_THAT(status, Ne(OSResult::Success));
-    ASSERT_THAT(response, Eq(TimeSpanFromMilliseconds(0u)));
+    ASSERT_THAT(response, Eq(milliseconds(0)));
 }
 
 class AntennaDeploymentStatusTest

--- a/unit_tests/antenna/miniport.cpp
+++ b/unit_tests/antenna/miniport.cpp
@@ -41,8 +41,7 @@ using testing::Invoke;
 using testing::ElementsAre;
 using gsl::span;
 using drivers::i2c::I2CResult;
-using std::chrono::milliseconds;
-using std::chrono::seconds;
+using namespace std::chrono_literals;
 
 class AntennaMiniportTest : public testing::Test
 {
@@ -102,14 +101,14 @@ TEST_F(AntennaMiniportTest, TestDisarmingDeploymentFailure)
 TEST_F(AntennaMiniportTest, TestAutomaticDeployment)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, BeginsWith(StartDeployment))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, seconds(200));
+    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, 200s);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestAutomaticDeploymentFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, BeginsWith(StartDeployment))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, seconds(200));
+    const auto status = miniport.InitializeAutomaticDeployment(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, 200s);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -130,28 +129,28 @@ TEST_F(AntennaMiniportTest, TestCancelAutomaticDeploymentFailure)
 TEST_F(AntennaMiniportTest, TestManualAntennaDeployment)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna1, 200u))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, seconds(200), false);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, 200s, false);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna2, 200u))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, seconds(200), false);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, 200s, false);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentWithOverride)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_PRIMARY_CHANNEL, ElementsAre(DeployAntenna1Override, 200u))).WillOnce(Return(I2CResult::OK));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, seconds(200), true);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, 200s, true);
     ASSERT_THAT(status, Eq(OSResult::Success));
 }
 
 TEST_F(AntennaMiniportTest, TestManualAntennaDeploymentWithOverrideFailure)
 {
     EXPECT_CALL(i2c, Write(ANTENNA_BACKUP_CHANNEL, ElementsAre(DeployAntenna3Override, 200u))).WillOnce(Return(I2CResult::Nack));
-    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, seconds(200), true);
+    const auto status = miniport.DeployAntenna(&miniport, &i2c, ANTENNA_BACKUP_CHANNEL, ANTENNA3_ID, 200s, true);
     ASSERT_THAT(status, Ne(OSResult::Success));
 }
 
@@ -225,19 +224,19 @@ TEST_F(AntennaMiniportTest, TestAntennaActivationTime)
             outData[0] = 10;
             return I2CResult::OK;
         }));
-    milliseconds response;
+    std::chrono::milliseconds response;
     const auto status = miniport.GetAntennaActivationTime(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA1_ID, &response);
     ASSERT_THAT(status, Eq(OSResult::Success));
-    ASSERT_THAT(response, Eq(milliseconds(128000)));
+    ASSERT_THAT(response, Eq(128000ms));
 }
 
 TEST_F(AntennaMiniportTest, TestAntennaActivationTimeFailure)
 {
     EXPECT_CALL(i2c, WriteRead(ANTENNA_PRIMARY_CHANNEL, ElementsAre(QueryActivationTime2), _)).WillOnce(Return(I2CResult::Nack));
-    milliseconds response;
+    std::chrono::milliseconds response;
     const auto status = miniport.GetAntennaActivationTime(&miniport, &i2c, ANTENNA_PRIMARY_CHANNEL, ANTENNA2_ID, &response);
     ASSERT_THAT(status, Ne(OSResult::Success));
-    ASSERT_THAT(response, Eq(milliseconds(0)));
+    ASSERT_THAT(response, Eq(0ms));
 }
 
 class AntennaDeploymentStatusTest

--- a/unit_tests/mock/AntennaMock.cpp
+++ b/unit_tests/mock/AntennaMock.cpp
@@ -18,7 +18,7 @@ static OSResult FinishDeployment(struct AntennaDriver* driver, AntennaChannel ch
 static OSResult DeployAntenna(struct AntennaDriver* driver,
     AntennaChannel channel,
     AntennaId antennaId,
-    TimeSpan timeout,
+    std::chrono::milliseconds timeout,
     bool overrideSwitches //
     )
 {

--- a/unit_tests/mock/AntennaMock.hpp
+++ b/unit_tests/mock/AntennaMock.hpp
@@ -19,7 +19,7 @@ struct AntennaMock : public AntennaDriver
     MOCK_METHOD4(DeployAntenna,
         OSResult(AntennaChannel channel,
             AntennaId antennaId,
-            TimeSpan timeout,
+            std::chrono::milliseconds timeout,
             bool overrideSwitches //
             ));
 

--- a/unit_tests/os/TimeoutTest.cpp
+++ b/unit_tests/os/TimeoutTest.cpp
@@ -28,22 +28,22 @@ TimeoutTest::TimeoutTest()
 
 TEST_F(TimeoutTest, ZeroTimeoutWillExpireImmediately)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
 
-    Timeout t(OSTaskTimeSpan(0));
+    Timeout t(std::chrono::milliseconds(0));
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }
 
 TEST_F(TimeoutTest, TimeoutWillExpireAfterSpecifiedNumberOfMiliseconds)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(100)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(100)));
 
-    Timeout t(OSTaskTimeSpan(10));
+    Timeout t(std::chrono::milliseconds(10));
 
     ASSERT_THAT(t.Expired(), Eq(false));
 
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(110)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(110)));
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }

--- a/unit_tests/os/TimeoutTest.cpp
+++ b/unit_tests/os/TimeoutTest.cpp
@@ -28,22 +28,22 @@ TimeoutTest::TimeoutTest()
 
 TEST_F(TimeoutTest, ZeroTimeoutWillExpireImmediately)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(0)));
 
-    Timeout t(0);
+    Timeout t(OSTaskTimeSpan(0));
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }
 
 TEST_F(TimeoutTest, TimeoutWillExpireAfterSpecifiedNumberOfMiliseconds)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(100));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(100)));
 
-    Timeout t(10);
+    Timeout t(OSTaskTimeSpan(10));
 
     ASSERT_THAT(t.Expired(), Eq(false));
 
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(110));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(OSTaskTimeSpan(110)));
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }

--- a/unit_tests/os/TimeoutTest.cpp
+++ b/unit_tests/os/TimeoutTest.cpp
@@ -10,6 +10,7 @@
 using testing::Test;
 using testing::Return;
 using testing::Eq;
+using namespace std::chrono_literals;
 
 class TimeoutTest : public Test
 {
@@ -28,22 +29,22 @@ TimeoutTest::TimeoutTest()
 
 TEST_F(TimeoutTest, ZeroTimeoutWillExpireImmediately)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(0)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(0ms));
 
-    Timeout t(std::chrono::milliseconds(0));
+    Timeout t(0ms);
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }
 
 TEST_F(TimeoutTest, TimeoutWillExpireAfterSpecifiedNumberOfMiliseconds)
 {
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(100)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(100ms));
 
-    Timeout t(std::chrono::milliseconds(10));
+    Timeout t(10ms);
 
     ASSERT_THAT(t.Expired(), Eq(false));
 
-    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(std::chrono::milliseconds(110)));
+    EXPECT_CALL(this->_os, GetUptime()).WillRepeatedly(Return(110ms));
 
     ASSERT_THAT(t.Expired(), Eq(true));
 }

--- a/unit_tests/os/os.cpp
+++ b/unit_tests/os/os.cpp
@@ -1,6 +1,8 @@
 #include "os.hpp"
 #include <utility>
 
+using namespace std::chrono_literals;
+
 static IOS* OSProxy = nullptr;
 
 OSResult System::CreateTask(OSTaskProcedure entryPoint, //
@@ -252,7 +254,7 @@ std::chrono::milliseconds System::GetUptime()
         return OSProxy->GetUptime();
     }
 
-    return std::chrono::milliseconds(0);
+    return 0ms;
 }
 
 void System::Yield()

--- a/unit_tests/os/os.cpp
+++ b/unit_tests/os/os.cpp
@@ -252,7 +252,7 @@ OSTaskTimeSpan System::GetUptime()
         return OSProxy->GetUptime();
     }
 
-    return 0;
+    return OSTaskTimeSpan(0);
 }
 
 void System::Yield()

--- a/unit_tests/os/os.cpp
+++ b/unit_tests/os/os.cpp
@@ -28,7 +28,7 @@ void System::RunScheduler(void)
     }
 }
 
-void System::SleepTask(const OSTaskTimeSpan time)
+void System::SleepTask(const std::chrono::milliseconds time)
 {
     if (OSProxy != nullptr)
     {
@@ -72,7 +72,7 @@ OSResult System::GiveSemaphore(OSSemaphoreHandle semaphore)
     return OSResult::InvalidOperation;
 }
 
-OSResult System::TakeSemaphore(OSSemaphoreHandle semaphore, OSTaskTimeSpan timeout)
+OSResult System::TakeSemaphore(OSSemaphoreHandle semaphore, std::chrono::milliseconds timeout)
 {
     if (OSProxy != nullptr)
     {
@@ -113,7 +113,7 @@ OSEventBits System::EventGroupClearBits(OSEventGroupHandle eventGroup, const OSE
 }
 
 OSEventBits System::EventGroupWaitForBits(
-    OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const OSTaskTimeSpan timeout)
+    OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const std::chrono::milliseconds timeout)
 {
     if (OSProxy != nullptr)
     {
@@ -161,7 +161,7 @@ OSQueueHandle System::CreateQueue(size_t maxElementCount, size_t elementSize)
     return nullptr;
 }
 
-bool System::QueueReceive(OSQueueHandle queue, void* element, OSTaskTimeSpan timeout)
+bool System::QueueReceive(OSQueueHandle queue, void* element, std::chrono::milliseconds timeout)
 {
     if (OSProxy != nullptr)
     {
@@ -181,7 +181,7 @@ bool System::QueueReceiveFromISR(OSQueueHandle queue, void* element)
     return false;
 }
 
-bool System::QueueSend(OSQueueHandle queue, const void* element, OSTaskTimeSpan timeout)
+bool System::QueueSend(OSQueueHandle queue, const void* element, std::chrono::milliseconds timeout)
 {
     if (OSProxy != nullptr)
     {
@@ -219,7 +219,7 @@ OSPulseHandle System::CreatePulseAll(void)
     return 0;
 }
 
-OSResult System::PulseWait(OSPulseHandle handle, OSTaskTimeSpan timeout)
+OSResult System::PulseWait(OSPulseHandle handle, std::chrono::milliseconds timeout)
 {
     if (OSProxy != nullptr)
     {
@@ -245,14 +245,14 @@ void System::EndSwitchingISR()
     }
 }
 
-OSTaskTimeSpan System::GetUptime()
+std::chrono::milliseconds System::GetUptime()
 {
     if (OSProxy != nullptr)
     {
         return OSProxy->GetUptime();
     }
 
-    return OSTaskTimeSpan(0);
+    return std::chrono::milliseconds(0);
 }
 
 void System::Yield()

--- a/unit_tests/os/os.hpp
+++ b/unit_tests/os/os.hpp
@@ -22,13 +22,13 @@ struct IOS
 
     virtual void RunScheduller() = 0;
 
-    virtual void Sleep(const OSTaskTimeSpan time) = 0;
+    virtual void Sleep(const std::chrono::milliseconds time) = 0;
 
     virtual OSSemaphoreHandle CreateBinarySemaphore(uint8_t semaphoreId = 0) = 0;
 
     virtual OSResult GiveSemaphore(const OSSemaphoreHandle semaphore) = 0;
 
-    virtual OSResult TakeSemaphore(const OSSemaphoreHandle semaphore, const OSTaskTimeSpan timeout) = 0;
+    virtual OSResult TakeSemaphore(const OSSemaphoreHandle semaphore, const std::chrono::milliseconds timeout) = 0;
 
     virtual OSEventGroupHandle CreateEventGroup() = 0;
 
@@ -36,29 +36,32 @@ struct IOS
 
     virtual OSEventBits EventGroupClearBits(OSEventGroupHandle eventGroup, const OSEventBits bitsToChange) = 0;
 
-    virtual OSEventBits EventGroupWaitForBits(
-        OSEventGroupHandle eventGroup, const OSEventBits bitsToWaitFor, bool waitAll, bool autoReset, const OSTaskTimeSpan timeout) = 0;
+    virtual OSEventBits EventGroupWaitForBits(OSEventGroupHandle eventGroup,
+        const OSEventBits bitsToWaitFor,
+        bool waitAll,
+        bool autoReset,
+        const std::chrono::milliseconds timeout) = 0;
 
     virtual OSEventBits EventGroupSetBitsISR(OSEventGroupHandle eventGroup, const OSEventBits bitsToChange) = 0;
 
     virtual void* Alloc(std::size_t size) = 0;
     virtual void Free(void* ptr) = 0;
     virtual OSQueueHandle CreateQueue(std::size_t maxElementCount, std::size_t elementSize) = 0;
-    virtual bool QueueReceive(OSQueueHandle queue, void* element, OSTaskTimeSpan timeout) = 0;
+    virtual bool QueueReceive(OSQueueHandle queue, void* element, std::chrono::milliseconds timeout) = 0;
     virtual bool QueueReceiveFromISR(OSQueueHandle queue, void* element) = 0;
-    virtual bool QueueSend(OSQueueHandle queue, const void* element, OSTaskTimeSpan timeout) = 0;
+    virtual bool QueueSend(OSQueueHandle queue, const void* element, std::chrono::milliseconds timeout) = 0;
     virtual bool QueueSendISR(OSQueueHandle queue, const void* element) = 0;
     virtual void QueueOverwrite(OSQueueHandle queue, const void* element) = 0;
 
     virtual OSPulseHandle CreatePulseAll() = 0;
 
-    virtual OSResult PulseWait(OSPulseHandle handle, OSTaskTimeSpan timeout) = 0;
+    virtual OSResult PulseWait(OSPulseHandle handle, std::chrono::milliseconds timeout) = 0;
 
     virtual void PulseSet(OSPulseHandle handle) = 0;
 
     virtual void EndSwitchingISR() = 0;
 
-    virtual OSTaskTimeSpan GetUptime() = 0;
+    virtual std::chrono::milliseconds GetUptime() = 0;
 
     virtual void Yield() = 0;
 };

--- a/unit_tests/time/SmartWait.cpp
+++ b/unit_tests/time/SmartWait.cpp
@@ -52,14 +52,16 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfDesiredTimeReached)
 {
     timeProvider.SetCurrentTime(TimePointBuild(0, 0, 0, 0, 0));
 
-    EXPECT_CALL(osMock, PulseWait(_, _)).Times(10).WillRepeatedly(Invoke([&](OSPulseHandle handle, const OSTaskTimeSpan timeout) {
-        UNUSED(handle, timeout);
+    EXPECT_CALL(osMock, PulseWait(_, _))
+        .Times(10)
+        .WillRepeatedly(Invoke([&](OSPulseHandle handle, const std::chrono::milliseconds timeout) {
+            UNUSED(handle, timeout);
 
-        Option<TimeSpan> currentTime = timeProvider.GetCurrentTime();
+            Option<std::chrono::milliseconds> currentTime = timeProvider.GetCurrentTime();
 
-        timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + TimeSpanFromMinutes(1)));
-        return OSResult::Success;
-    }));
+            timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + std::chrono::minutes(1)));
+            return OSResult::Success;
+        }));
 
     auto result = timeProvider.LongDelayUntil(TimePointBuild(0, 0, 10, 0, 0));
 
@@ -70,14 +72,16 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfMissionTimeJumpsOverDesiredTi
 {
     timeProvider.SetCurrentTime(TimePointBuild(0, 0, 0, 0, 0));
 
-    EXPECT_CALL(osMock, PulseWait(_, _)).Times(11).WillRepeatedly(Invoke([&](OSPulseHandle handle, const OSTaskTimeSpan timeout) {
-        UNUSED(handle, timeout);
+    EXPECT_CALL(osMock, PulseWait(_, _))
+        .Times(11)
+        .WillRepeatedly(Invoke([&](OSPulseHandle handle, const std::chrono::milliseconds timeout) {
+            UNUSED(handle, timeout);
 
-        Option<TimeSpan> currentTime = timeProvider.GetCurrentTime();
+            Option<std::chrono::milliseconds> currentTime = timeProvider.GetCurrentTime();
 
-        timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + TimeSpanFromMinutes(1)));
-        return OSResult::Success;
-    }));
+            timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + std::chrono::minutes(1)));
+            return OSResult::Success;
+        }));
 
     auto result = timeProvider.LongDelayUntil(TimePointBuild(0, 0, 10, 30, 0));
 

--- a/unit_tests/time/SmartWait.cpp
+++ b/unit_tests/time/SmartWait.cpp
@@ -13,6 +13,7 @@ using testing::_;
 using testing::Invoke;
 using testing::Return;
 using services::time::TimeProvider;
+using namespace std::chrono_literals;
 
 class SmartWaitTest : public Test
 {
@@ -59,7 +60,7 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfDesiredTimeReached)
 
             Option<std::chrono::milliseconds> currentTime = timeProvider.GetCurrentTime();
 
-            timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + std::chrono::minutes(1)));
+            timeProvider.SetCurrentTime(TimePointFromDuration(currentTime.Value + 1min));
             return OSResult::Success;
         }));
 
@@ -79,7 +80,7 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfMissionTimeJumpsOverDesiredTi
 
             Option<std::chrono::milliseconds> currentTime = timeProvider.GetCurrentTime();
 
-            timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + std::chrono::minutes(1)));
+            timeProvider.SetCurrentTime(TimePointFromDuration(currentTime.Value + 1min));
             return OSResult::Success;
         }));
 

--- a/unit_tests/time/SmartWait.cpp
+++ b/unit_tests/time/SmartWait.cpp
@@ -57,7 +57,7 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfDesiredTimeReached)
 
         Option<TimeSpan> currentTime = timeProvider.GetCurrentTime();
 
-        timeProvider.SetCurrentTime(TimePointFromTimeSpan(TimeSpanAdd(currentTime.Value, TimeSpanFromMinutes(1))));
+        timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + TimeSpanFromMinutes(1)));
         return OSResult::Success;
     }));
 
@@ -75,7 +75,7 @@ TEST_F(SmartWaitTest, ShouldWaitForPulseAndReturnIfMissionTimeJumpsOverDesiredTi
 
         Option<TimeSpan> currentTime = timeProvider.GetCurrentTime();
 
-        timeProvider.SetCurrentTime(TimePointFromTimeSpan(TimeSpanAdd(currentTime.Value, TimeSpanFromMinutes(1))));
+        timeProvider.SetCurrentTime(TimePointFromTimeSpan(currentTime.Value + TimeSpanFromMinutes(1)));
         return OSResult::Success;
     }));
 

--- a/unit_tests/time/TimeSpan.hpp
+++ b/unit_tests/time/TimeSpan.hpp
@@ -13,19 +13,4 @@ inline bool operator<(const TimePoint& left, const TimePoint& right)
     return TimePointLessThan(left, right);
 }
 
-inline bool operator==(const TimeSpan& left, const TimeSpan& right)
-{
-    return TimeSpanEqual(left, right);
-}
-
-inline bool operator!=(const TimeSpan& left, const TimeSpan& right)
-{
-    return TimeSpanNotEqual(left, right);
-}
-
-inline bool operator<(const TimeSpan& left, const TimeSpan& right)
-{
-    return TimeSpanLessThan(left, right);
-}
-
 #endif /* UNIT_TESTS_TIME_TIMESPAN_HPP_ */

--- a/unit_tests/time/persistance.cpp
+++ b/unit_tests/time/persistance.cpp
@@ -175,9 +175,9 @@ TEST_F(TimerPersistanceTest, TestReadingThreeFilesTwoSame)
 
 TEST_F(TimerPersistanceTest, TestReadingThreeDifferentFiles)
 {
-    std::array<const uint8_t, 8> a{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x78};
-    std::array<const uint8_t, 8> b{0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
-    std::array<const uint8_t, 8> c{0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa};
+    std::array<const uint8_t, 8> a{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x70};
+    std::array<const uint8_t, 8> b{0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x75};
+    std::array<const uint8_t, 8> c{0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x79};
     EXPECT_CALL(fs, Open(_, _, _))
         .WillOnce(Return(MakeOpenedFile(1)))
         .WillOnce(Return(MakeOpenedFile(2)))
@@ -199,7 +199,7 @@ TEST_F(TimerPersistanceTest, TestReadingThreeDifferentFiles)
     }));
 
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x7877665544332211ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x7077665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateSaveError)

--- a/unit_tests/time/persistance.cpp
+++ b/unit_tests/time/persistance.cpp
@@ -17,12 +17,13 @@ using testing::HasSubstr;
 using testing::ElementsAreArray;
 using services::time::TimeProvider;
 using services::fs::FileHandle;
+using std::chrono::milliseconds;
 
 class TimerPersistanceTest : public testing::Test
 {
   protected:
     TimerPersistanceTest();
-    TimeSpan GetCurrentTime();
+    milliseconds GetCurrentTime();
 
     TimeProvider provider;
     testing::NiceMock<FsMock> fs;
@@ -30,9 +31,9 @@ class TimerPersistanceTest : public testing::Test
     OSReset osGuard;
 };
 
-TimeSpan TimerPersistanceTest::GetCurrentTime()
+std::chrono::milliseconds TimerPersistanceTest::GetCurrentTime()
 {
-    Option<TimeSpan> span = provider.GetCurrentTime();
+    Option<std::chrono::milliseconds> span = provider.GetCurrentTime();
     EXPECT_TRUE(span.HasValue);
     return span.Value;
 }
@@ -55,7 +56,7 @@ TEST_F(TimerPersistanceTest, TestReadingStateNoState)
 {
     EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResult::NotFound)));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingStateEmptyFiles)
@@ -64,7 +65,7 @@ TEST_F(TimerPersistanceTest, TestReadingStateEmptyFiles)
     EXPECT_CALL(fs, Read(_, _)).WillRepeatedly(Return(MakeFSIOResult(OSResult::InvalidOperation)));
     EXPECT_CALL(fs, Close(_)).WillRepeatedly(Return(OSResult::Success));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFiles)
@@ -76,7 +77,7 @@ TEST_F(TimerPersistanceTest, TestReadingFiles)
         return MakeFSIOResult(buffer);
     }));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingSingleNonEmptyFile)
@@ -90,7 +91,7 @@ TEST_F(TimerPersistanceTest, TestReadingSingleNonEmptyFile)
         }))
         .WillRepeatedly(Return(MakeFSIOResult(OSResult::InvalidOperation)));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0u)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0u)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingTwoNonEmptyFiles)
@@ -104,7 +105,7 @@ TEST_F(TimerPersistanceTest, TestReadingTwoNonEmptyFiles)
             return MakeFSIOResult(buffer);
         }));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingTwoExistingEmptyFiles)
@@ -116,7 +117,7 @@ TEST_F(TimerPersistanceTest, TestReadingTwoExistingEmptyFiles)
         return MakeFSIOResult(buffer);
     }));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x1111111111111111ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x1111111111111111ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFilesEndiannes)
@@ -138,7 +139,7 @@ TEST_F(TimerPersistanceTest, TestReadingFilesEndiannes)
         }
     }));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x8877665544332211ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x8877665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingFilesGetClosed)
@@ -170,7 +171,7 @@ TEST_F(TimerPersistanceTest, TestReadingThreeFilesTwoSame)
             return MakeFSIOResult(buffer);
         }));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x8877665544332211ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x8877665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestReadingThreeDifferentFiles)
@@ -199,15 +200,15 @@ TEST_F(TimerPersistanceTest, TestReadingThreeDifferentFiles)
     }));
 
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x7077665544332211ull)));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x7077665544332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateSaveError)
 {
     EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(OSResult::NotFound)));
     EXPECT_TRUE(provider.Initialize(TimePassedProxy, nullptr));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(0x44332211ull));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
+    provider.AdvanceTime(milliseconds(0x44332211ull));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWriteError)
@@ -217,8 +218,8 @@ TEST_F(TimerPersistanceTest, TestStateWriteError)
     EXPECT_CALL(fs, Open(_, _, _)).WillRepeatedly(Return(MakeOpenedFile(1)));
     EXPECT_CALL(fs, Write(_, _)).WillRepeatedly(Return(MakeFSIOResult(OSResult::InvalidOperation)));
     ON_CALL(fs, Close(_)).WillByDefault(Return(OSResult::Success));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(0x44332211ull));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
+    provider.AdvanceTime(milliseconds(0x44332211ull));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWrite)
@@ -233,8 +234,8 @@ TEST_F(TimerPersistanceTest, TestStateWrite)
 
         return MakeFSIOResult(buffer);
     }));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(0x44332211ull));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
+    provider.AdvanceTime(milliseconds(0x44332211ull));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWriteClosesFiles)
@@ -248,8 +249,8 @@ TEST_F(TimerPersistanceTest, TestStateWriteClosesFiles)
     EXPECT_CALL(fs, Close(2)).Times(3);
     EXPECT_CALL(fs, Close(3)).Times(3);
     EXPECT_CALL(fs, Write(_, _)).WillRepeatedly(Return(MakeFSIOResult(OSResult::InvalidOperation)));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(0x44332211ull));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(0x44332211ull)));
+    provider.AdvanceTime(milliseconds(0x44332211ull));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(0x44332211ull)));
 }
 
 TEST_F(TimerPersistanceTest, TestStateWriteIsNotDoneOnEveryTimeUpdate)
@@ -260,9 +261,9 @@ TEST_F(TimerPersistanceTest, TestStateWriteIsNotDoneOnEveryTimeUpdate)
     EXPECT_CALL(fs, Close(_)).Times(9);
     EXPECT_CALL(fs, Write(_, _)).WillRepeatedly(Return(MakeFSIOResult(OSResult::InvalidOperation)));
 
-    provider.AdvanceTime(TimeSpanFromMilliseconds(400000));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(100000));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(300000));
-    provider.AdvanceTime(TimeSpanFromMilliseconds(200000));
-    ASSERT_THAT(GetCurrentTime(), Eq(TimeSpanFromMilliseconds(1000000ull)));
+    provider.AdvanceTime(milliseconds(400000));
+    provider.AdvanceTime(milliseconds(100000));
+    provider.AdvanceTime(milliseconds(300000));
+    provider.AdvanceTime(milliseconds(200000));
+    ASSERT_THAT(GetCurrentTime(), Eq(milliseconds(1000000ull)));
 }

--- a/unit_tests/time/time.cpp
+++ b/unit_tests/time/time.cpp
@@ -9,21 +9,21 @@ TEST(TimeTest, TestTimePointToTimeSpanConversionBase)
 {
     const auto point = TimePointBuild(40, 12, 12, 35, 876);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.count(), Eq(3499955876ull));
+    ASSERT_THAT(result.count(), Eq(3499955876ll));
 }
 
 TEST(TimeTest, TestTimePointToTimeSpanConversionExtended)
 {
     const auto point = TimePointBuild(65, 17, 43, 59, 500);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.count(), Eq(5679839500ull));
+    ASSERT_THAT(result.count(), Eq(5679839500ll));
 }
 
 TEST(TimeTest, TestTimePointToTimeSpanConversionFieldOverflow)
 {
     const auto point = TimePointBuild(4501, 80, 200, 150, 12548);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.count(), Eq(389186562548ull));
+    ASSERT_THAT(result.count(), Eq(389186562548ll));
 }
 
 TEST(TimeTest, TestTimePointNormalization)

--- a/unit_tests/time/time.cpp
+++ b/unit_tests/time/time.cpp
@@ -1,7 +1,7 @@
-#include "time/TimePoint.h"
 #include "gtest/gtest.h"
 #include "gmock/gmock-matchers.h"
 #include "TimeSpan.hpp"
+#include "time/TimePoint.h"
 
 using testing::Eq;
 
@@ -9,21 +9,21 @@ TEST(TimeTest, TestTimePointToTimeSpanConversionBase)
 {
     const auto point = TimePointBuild(40, 12, 12, 35, 876);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.value, Eq(3499955876ull));
+    ASSERT_THAT(result.count(), Eq(3499955876ull));
 }
 
 TEST(TimeTest, TestTimePointToTimeSpanConversionExtended)
 {
     const auto point = TimePointBuild(65, 17, 43, 59, 500);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.value, Eq(5679839500ull));
+    ASSERT_THAT(result.count(), Eq(5679839500ull));
 }
 
 TEST(TimeTest, TestTimePointToTimeSpanConversionFieldOverflow)
 {
     const auto point = TimePointBuild(4501, 80, 200, 150, 12548);
     const auto result = TimePointToTimeSpan(point);
-    ASSERT_THAT(result.value, Eq(389186562548ull));
+    ASSERT_THAT(result.count(), Eq(389186562548ull));
 }
 
 TEST(TimeTest, TestTimePointNormalization)


### PR DESCRIPTION
I replaced implementation of `TimeSpan` with `std::chrono::duration<uint64_t>`. 
Some methods were removed because they duplicated `std::chrono::duration` built-in functionality.
I left `TimePoint` becasue it seems tailored for this system needs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/66)
<!-- Reviewable:end -->
