### PR TITLE
Fix converting RTOS ticks into duration

### DIFF
--- a/libs/free_rtos_wrapper/os.cpp
+++ b/libs/free_rtos_wrapper/os.cpp
@@ -226,7 +226,7 @@ void System::PulseSet(OSPulseHandle handle)
 
 milliseconds System::GetUptime()
 {
-    typedef std::ratio<portTICK_PERIOD_MS, 1> ticksPerMs;
+    typedef std::ratio<portTICK_PERIOD_MS, 1000> ticksPerMs;
     typedef std::chrono::duration<int64_t, ticksPerMs> ticks;
 
     return std::chrono::duration_cast<milliseconds>(ticks(xTaskGetTickCount()));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/70)
<!-- Reviewable:end -->
