### PR TITLE
Change FS terminal commands to allow operating on any file

### DIFF
--- a/integration_tests/obc/file_system.py
+++ b/integration_tests/obc/file_system.py
@@ -1,3 +1,5 @@
+import struct
+
 from .obc_mixin import OBCMixin, command, decode_lines
 
 
@@ -10,13 +12,11 @@ class FileSystemMixin(OBCMixin):
     def list_files(self, path):
         pass
 
-    @command("writeFile {0} {1}")
     def write_file(self, path, content):
-        pass
+        return int(self._terminal.command_with_write_data("writeFile {0}".format(path), content))
 
-    @command("readFile {0}")
     def read_file(self, path):
-        pass
+        return self._terminal.command_with_read_data("readFile {0}".format(path))
 
     @command("sync_fs")
     def sync_fs(self):

--- a/integration_tests/tests/test_fs.py
+++ b/integration_tests/tests/test_fs.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from system import wait_for_obc_start
 from tests.base import BaseTest
 
@@ -18,3 +19,19 @@ class FileSystemTests(BaseTest):
 
         read_back = self.system.obc.read_file("/test_file")
         self.assertEqual(read_back, text)
+
+    @wait_for_obc_start()
+    def test_write_read_long_file(self):
+        path = "/b"
+        data = '\n'.join(map(lambda x: x * 25, ['A', 'B', '>', 'C', 'D', 'E', 'F', 'G']))
+
+        self.system.obc.write_file(path, data)
+
+        files = self.system.obc.list_files("/")
+
+        self.assertListEqual(files, ['b', 'lost+found'])
+
+        read_back = self.system.obc.read_file("/b")
+
+        self.assertEqual(read_back, data)
+

--- a/libs/drivers/leuart/Include/leuart/line_io.h
+++ b/libs/drivers/leuart/Include/leuart/line_io.h
@@ -3,6 +3,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <cstdint>
 #include <gsl/span>
 
 /**
@@ -32,16 +33,23 @@ typedef struct _LineIO
      * @brief Procedure that print given buffer char-by-char. Useful for not null terminated strings
      * @param[in] buffer Buffer to print
      */
-    void (*PrintBuffer)(gsl::span<const char> buffer);
+    void (*PrintBuffer)(gsl::span<const std::uint8_t> buffer);
 
     /**
-     *
-     * @param io Procedure that reads single line of text
+     * @brief Procedure that reads single line of text
+     * @param io @see LineIO structure
      * @param buffer Buffer that will hold upcoming data
      * @param bufferLength Maximum length of buffer
      * @return Count of read characters
      */
     size_t (*Readline)(struct _LineIO* io, char* buffer, size_t bufferLength);
+
+    /**
+     * @brief Reads arbitrary number of bytes
+     * @param io @see LineIO structure
+     * @param buffer Buffer that will be filled
+     */
+    void (*ReadBuffer)(struct _LineIO* io, gsl::span<std::uint8_t> buffer);
 } LineIO;
 
 #endif /* LIBS_DRIVERS_LEUART_INCLUDE_LEUART_LINE_IO_H_ */

--- a/libs/fs/Include/fs/fs.h
+++ b/libs/fs/Include/fs/fs.h
@@ -194,6 +194,13 @@ namespace services
              * @return true if path exists
              */
             virtual bool Exists(const char* path) = 0;
+
+            /**
+             * @brief Gets file size
+             * @param file File handle
+             * @return Size of file
+             */
+            virtual FileSize GetFileSize(FileHandle file) = 0;
         };
 
         /**
@@ -272,6 +279,12 @@ namespace services
              * @return Operation result
              */
             OSResult Truncate(FileSize size);
+
+            /**
+             * @brief Returns size of opened file
+             * @return File size
+             */
+            FileSize Size();
 
           private:
             /** @brief File system interface */

--- a/libs/fs/Include/fs/yaffs.h
+++ b/libs/fs/Include/fs/yaffs.h
@@ -58,6 +58,7 @@ namespace services
             virtual OSResult Format(const char* mountPoint) override;
             virtual OSResult MakeDirectory(const char* path) override;
             virtual bool Exists(const char* path) override;
+            virtual FileSize GetFileSize(FileHandle file) override;
 
             virtual OSResult ClearDevice(yaffs_dev* device) override;
 

--- a/libs/fs/extension.cpp
+++ b/libs/fs/extension.cpp
@@ -73,3 +73,8 @@ OSResult File::Truncate(FileSize size)
 {
     return this->_fs.TruncateFile(this->_handle, size);
 }
+
+FileSize File::Size()
+{
+    return this->_fs.GetFileSize(this->_handle);
+}

--- a/libs/fs/yaffs.cpp
+++ b/libs/fs/yaffs.cpp
@@ -217,6 +217,15 @@ void YaffsFileSystem::Initialize()
     YaffsGlueInit();
 }
 
+FileSize YaffsFileSystem::GetFileSize(FileHandle file)
+{
+    struct yaffs_stat stat;
+
+    yaffs_fstat(file, &stat);
+
+    return stat.st_size;
+}
+
 OSResult YaffsFileSystem::AddDeviceAndMount(yaffs_dev* device)
 {
     yaffs_add_device(device);

--- a/libs/terminal/include/terminal/terminal.h
+++ b/libs/terminal/include/terminal/terminal.h
@@ -61,7 +61,7 @@ class Terminal
      * @brief Prints formatted text
      * @param[in] text Text to print with format placeholders
      */
-    void Printf(const char* text, ...);
+    void Printf(const char* text, ...) __attribute__((format(printf, 2, 3)));
 
     /**
      * @brief Prints text
@@ -73,7 +73,13 @@ class Terminal
      * @brief Print not-terminated buffer
      * @param[in] buffer Buffer to print
      */
-    void PrintBuffer(gsl::span<const char> buffer);
+    void PrintBuffer(gsl::span<const std::uint8_t> buffer);
+
+    /**
+     * @brief Reads number of bytes
+     * @param buffer Buffer to read to
+     */
+    void ReadBuffer(gsl::span<std::uint8_t> buffer);
 
   private:
     /**
@@ -109,6 +115,52 @@ class Terminal
      * @brief Command list
      */
     gsl::span<const TerminalCommandDescription> _commandList;
+};
+
+/**
+ * @brief Support class for reading lengthy data from terminal in parts
+ *
+ * Transfer is performed using following protocol:
+ * Host (H), Device (D)
+ * @verbatim
+ * D: #
+ * H: <Data length (32-bit, LE)>
+ * D: <Part length (32-bit LE)>
+ * H: <Requested number of bytes>
+ * D: <Part length (32-bit LE)>
+ * H: <Requested number of bytes>
+ * ...
+ * @endverbatim
+ */
+class TerminalPartialRetrival
+{
+  public:
+    /**
+     * @brief Initializes @see TerminalPartialRetrival instance
+     * @param terminal Terminal
+     * @param buffer Buffer used to store parts
+     */
+    TerminalPartialRetrival(Terminal& terminal, gsl::span<uint8_t> buffer);
+
+    /**
+     * @brief Initializes transfer
+     */
+    void Start();
+
+    /**
+     * @brief Reads single part from terminal
+     * @retval None of no more data to be retrieved
+     * @retval Some with span containing data read in current part
+     */
+    Option<gsl::span<uint8_t>> ReadPart();
+
+  private:
+    /** @brief Terminal */
+    Terminal& _terminal;
+    /** @brief Buffer used to store parts */
+    gsl::span<uint8_t> _buffer;
+    /** @brief Remaining data length */
+    std::size_t _remainingLength;
 };
 
 /** @} */

--- a/libs/terminal/terminal.cpp
+++ b/libs/terminal/terminal.cpp
@@ -1,6 +1,9 @@
 #include <string.h>
+#include <array>
 
 #include "base/os.h"
+#include "base/reader.h"
+#include "base/writer.h"
 #include "logger/logger.h"
 #include "system.h"
 #include "terminal.h"
@@ -30,6 +33,12 @@ static void parseCommandLine(char line[],
     }
 }
 
+Terminal::Terminal(LineIO& stdio)
+    : _stdio(stdio), //
+      _task("Terminal", this, Terminal::Loop)
+{
+}
+
 void Terminal::Puts(const char* text)
 {
     this->_stdio.Puts(&this->_stdio, text);
@@ -55,9 +64,14 @@ void Terminal::Printf(const char* text, ...)
     va_end(args);
 }
 
-void Terminal::PrintBuffer(gsl::span<const char> buffer)
+void Terminal::PrintBuffer(gsl::span<const std::uint8_t> buffer)
 {
     this->_stdio.PrintBuffer(buffer);
+}
+
+void Terminal::ReadBuffer(gsl::span<std::uint8_t> buffer)
+{
+    this->_stdio.ReadBuffer(&this->_stdio, buffer);
 }
 
 void Terminal::HandleCommand(char* buffer)
@@ -102,12 +116,6 @@ void Terminal::Loop(Terminal* terminal)
     }
 }
 
-Terminal::Terminal(LineIO& stdio)
-    : _stdio(stdio), //
-      _task("Terminal", this, Terminal::Loop)
-{
-}
-
 void Terminal::Initialize()
 {
     if (OS_RESULT_FAILED(this->_task.Create()))
@@ -123,4 +131,44 @@ void Terminal::Initialize()
 void Terminal::SetCommandList(gsl::span<const TerminalCommandDescription> commands)
 {
     this->_commandList = commands;
+}
+
+TerminalPartialRetrival::TerminalPartialRetrival(Terminal& terminal, gsl::span<uint8_t> buffer)
+    : _terminal(terminal), _buffer(buffer), _remainingLength(0)
+{
+}
+
+void TerminalPartialRetrival::Start()
+{
+    this->_terminal.Puts("#");
+
+    std::array<uint8_t, sizeof(std::uint32_t)> lengthBuffer;
+
+    this->_terminal.ReadBuffer(lengthBuffer);
+
+    Reader r(lengthBuffer);
+    this->_remainingLength = r.ReadDoubleWordLE();
+}
+
+Option<gsl::span<uint8_t>> TerminalPartialRetrival::ReadPart()
+{
+    if (this->_remainingLength == 0)
+    {
+        return Option<gsl::span<uint8_t>>::None();
+    }
+
+    auto partLength = std::min<std::size_t>(this->_buffer.size(), this->_remainingLength);
+    auto part = this->_buffer.subspan(0, partLength);
+
+    std::array<uint8_t, sizeof(std::uint32_t)> partLengthBuffer;
+    Writer w(partLengthBuffer);
+    w.WriteDoubleWordLE(static_cast<std::uint32_t>(part.size()));
+
+    this->_terminal.PrintBuffer(partLengthBuffer);
+
+    this->_terminal.ReadBuffer(part);
+
+    this->_remainingLength -= part.size();
+
+    return Option<gsl::span<uint8_t>>::Some(part);
 }

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 
 static void SendResult(OSResult result)
 {
-    Main.terminal.Printf("%d", result);
+    Main.terminal.Printf("%d", num(result));
 }
 
 static bool GetChannel(const char* name, AntennaChannel* channel)
@@ -121,7 +121,7 @@ void AntennaGetDeploymentStatus(uint16_t argc, char* argv[])
     else
     {
         Main.terminal.Printf("%d %d %d %d %d %d %d %d %d %d %d\n",
-            status,
+            num(status),
             ToInt(deploymentStatus.DeploymentStatus[0]),        //
             ToInt(deploymentStatus.DeploymentStatus[1]),        //
             ToInt(deploymentStatus.DeploymentStatus[2]),        //

--- a/src/commands/comm.cpp
+++ b/src/commands/comm.cpp
@@ -49,9 +49,7 @@ void ReceiveFrameHandler(uint16_t argc, char* argv[])
     {
         Main.Communication.CommDriver.RemoveFrame();
 
-        auto payload = frame.Payload();
-        auto payloadStr = reinterpret_cast<const char*>(payload.data());
-        Main.terminal.PrintBuffer(gsl::span<const char>(payloadStr, payload.size()));
+        Main.terminal.PrintBuffer(frame.Payload());
     }
 }
 

--- a/src/commands/i2c_test_command.cpp
+++ b/src/commands/i2c_test_command.cpp
@@ -63,6 +63,6 @@ void I2CTestCommandHandler(uint16_t argc, char* argv[])
     }
     else
     {
-        Main.terminal.Printf("Error %d\n", result);
+        Main.terminal.Printf("Error %d\n", num(result));
     }
 }

--- a/unit_tests/mock/FsMock.hpp
+++ b/unit_tests/mock/FsMock.hpp
@@ -22,6 +22,7 @@ struct FsMock : services::fs::IFileSystem
     MOCK_METHOD1(Format, OSResult(const char*));
     MOCK_METHOD1(MakeDirectory, OSResult(const char*));
     MOCK_METHOD1(Exists, bool(const char*));
+    MOCK_METHOD1(GetFileSize, services::fs::FileSize(services::fs::FileHandle));
 };
 
 services::fs::FileOpenResult MakeOpenedFile(int handle);


### PR DESCRIPTION
Currently `writeFile` and `readFile` commands are very limited. It is possible to write file command must fit into input buffer (100 bytes) with `writeFile path content` also it is not possible to write new line character as it will terminate command line reading. Simillary reading file that contains prompt (`>`) character will terminate reading file on Python side and lead to unusable terminal access.

This pull requests modifes `writeFile` and `readFile` commands to overcome this issues by:
* Writing file in chunks
* Reading exact number of bytes for terminal and not relaying on any special character

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/71)
<!-- Reviewable:end -->
