### PR TITLE
Reader & writer signed implementation

### DIFF
--- a/libs/base/Include/base/reader.h
+++ b/libs/base/Include/base/reader.h
@@ -76,6 +76,14 @@ class Reader final
     uint16_t ReadWordLE();
 
     /**
+     * @brief Read single 16 bit word with little-endian memory orientation from the buffer,
+     * convert it into signed value and advance the current buffer position to the next unread byte.
+     * Value is read asuuming 2's complement notation.
+     * @return Read signed word value.
+     */
+    int16_t ReadSignedWordLE();
+
+    /**
      * @brief Read single 16 bit word with big-endian memory orientation from the buffer
      * and advance the current buffer position to the next unread byte.
      * @return Read word.
@@ -88,6 +96,14 @@ class Reader final
      * @return Read double word.
      */
     uint32_t ReadDoubleWordLE();
+
+    /**
+     * @brief Read single 32 bit word with little-endian memory orientation from the buffer,
+     * convert it into signed value and advance the current buffer position to the next unread byte.
+     * Value is read asuuming 2's complement notation.
+     * @return Read signed double word value.
+     */
+    int32_t ReadSignedDoubleWordLE();
 
     /**
      * @brief Read single 32 bit word with big-endian memory orientation from the buffer

--- a/libs/base/Include/base/reader.h
+++ b/libs/base/Include/base/reader.h
@@ -78,7 +78,7 @@ class Reader final
     /**
      * @brief Read single 16 bit word with little-endian memory orientation from the buffer,
      * convert it into signed value and advance the current buffer position to the next unread byte.
-     * Value is read asuuming 2's complement notation.
+     * Value is read assuming 2's complement notation.
      * @return Read signed word value.
      */
     int16_t ReadSignedWordLE();
@@ -100,7 +100,7 @@ class Reader final
     /**
      * @brief Read single 32 bit word with little-endian memory orientation from the buffer,
      * convert it into signed value and advance the current buffer position to the next unread byte.
-     * Value is read asuuming 2's complement notation.
+     * Value is read assuming 2's complement notation.
      * @return Read signed double word value.
      */
     int32_t ReadSignedDoubleWordLE();

--- a/libs/base/Include/base/writer.h
+++ b/libs/base/Include/base/writer.h
@@ -98,6 +98,16 @@ bool WriterWriteByte(Writer* writer, uint8_t byte);
 bool WriterWriteWordLE(Writer* writer, uint16_t word);
 
 /**
+ * @brief Writes single 16 bit signed value with little-endian memory orientation to the buffer
+ * and advances the current buffer position to the next unused byte.
+ * Value is written in 2's complement notation.
+ * @param[in] writer Pointer to the writer object.
+ * @param[in] word Word that should be added to writer output using little endian byte ordering.
+ * @return Operation status.
+ */
+bool WriterWriteSignedWordLE(Writer* writer, int16_t word);
+
+/**
  * @brief Writes single 32 bit word with little-endian memory orientation to the buffer
  * and advances the current buffer position to the next unused byte.
  * @param[in] writer Pointer to the queried reader object.
@@ -105,6 +115,16 @@ bool WriterWriteWordLE(Writer* writer, uint16_t word);
  * @return Operation status.
  */
 bool WriterWriteDoubleWordLE(Writer* writer, uint32_t dword);
+
+/**
+ * @brief Writes single 32 bit signed value with little-endian memory orientation to the buffer
+ * and advances the current buffer position to the next unused byte.
+ * Value is written in 2's complement notation.
+ * @param[in] writer Pointer to the queried reader object.
+ * @param[in] dword Doubleword that should be added to writer output using little endian byte ordering.
+ * @return Operation status.
+ */
+bool WriterWriteSignedDoubleWordLE(Writer* writer, int32_t dword);
 
 /**
  * @brief Writes single 64 bit word with little-endian memory orientation to the buffer

--- a/libs/base/reader.cpp
+++ b/libs/base/reader.cpp
@@ -61,7 +61,7 @@ uint16_t Reader::ReadWordLE()
 
 int16_t Reader::ReadSignedWordLE()
 {
-    return (int16_t)(this->ReadWordLE());
+    return static_cast<int16_t>(this->ReadWordLE());
 }
 
 uint16_t Reader::ReadWordBE()
@@ -100,7 +100,7 @@ uint32_t Reader::ReadDoubleWordLE()
 
 int32_t Reader::ReadSignedDoubleWordLE()
 {
-    return (int32_t)(this->ReadDoubleWordLE());
+    return static_cast<int32_t>(this->ReadDoubleWordLE());
 }
 
 uint32_t Reader::ReadDoubleWordBE()

--- a/libs/base/reader.cpp
+++ b/libs/base/reader.cpp
@@ -59,6 +59,11 @@ uint16_t Reader::ReadWordLE()
     }
 }
 
+int16_t Reader::ReadSignedWordLE()
+{
+    return (int16_t)(this->ReadWordLE());
+}
+
 uint16_t Reader::ReadWordBE()
 {
     if (!UpdateState(2))
@@ -91,6 +96,11 @@ uint32_t Reader::ReadDoubleWordLE()
         value += this->buffer[this->position - 4];
         return value;
     }
+}
+
+int32_t Reader::ReadSignedDoubleWordLE()
+{
+    return (int32_t)(this->ReadDoubleWordLE());
 }
 
 uint32_t Reader::ReadDoubleWordBE()

--- a/libs/base/writer.cpp
+++ b/libs/base/writer.cpp
@@ -54,7 +54,7 @@ bool WriterWriteWordLE(Writer* writer, uint16_t word)
 
 bool WriterWriteSignedWordLE(Writer* writer, int16_t word)
 {
-    return WriterWriteWordLE(writer, (uint16_t)(word));
+    return WriterWriteWordLE(writer, static_cast<uint16_t>(word));
 }
 
 bool WriterWriteDoubleWordLE(Writer* writer, uint32_t word)
@@ -76,7 +76,7 @@ bool WriterWriteDoubleWordLE(Writer* writer, uint32_t word)
 
 bool WriterWriteSignedDoubleWordLE(Writer* writer, int32_t dword)
 {
-    return WriterWriteDoubleWordLE(writer, (uint32_t)(dword));
+    return WriterWriteDoubleWordLE(writer, static_cast<uint32_t>(dword));
 }
 
 bool WriterWriteQuadWordLE(Writer* writer, uint64_t word)

--- a/libs/base/writer.cpp
+++ b/libs/base/writer.cpp
@@ -52,6 +52,11 @@ bool WriterWriteWordLE(Writer* writer, uint16_t word)
     }
 }
 
+bool WriterWriteSignedWordLE(Writer* writer, int16_t word)
+{
+    return WriterWriteWordLE(writer, (uint16_t)(word));
+}
+
 bool WriterWriteDoubleWordLE(Writer* writer, uint32_t word)
 {
     if (!WriterUpdateState(writer, 4))
@@ -67,6 +72,11 @@ bool WriterWriteDoubleWordLE(Writer* writer, uint32_t word)
         writer->position += 4;
         return true;
     }
+}
+
+bool WriterWriteSignedDoubleWordLE(Writer* writer, int32_t dword)
+{
+    return WriterWriteDoubleWordLE(writer, (uint32_t)(dword));
 }
 
 bool WriterWriteQuadWordLE(Writer* writer, uint64_t word)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
   Comm/UplinkFrameDecoderTest.cpp
   base/ReaderTest.cpp
   base/WriterTest.cpp
+  base/RapidTest.cpp
   MissionPlan/MissionPlanTest.cpp
   MissionPlan/MissionTestHelpers.cpp
   MissionPlan/SailSystemStateTest.cpp

--- a/unit_tests/base/RapidTest.cpp
+++ b/unit_tests/base/RapidTest.cpp
@@ -3,16 +3,11 @@
 #include "rapidcheck.hpp"
 #include "rapidcheck/gtest.h"
 
-#include "system.h"
 #include "base/reader.h"
 #include "base/writer.h"
 
-using testing::Eq;
-using testing::ElementsAre;
-
-
 template<typename WriterFunction, typename ReaderMemberPtr, typename V>
-void WriterReaderRapidCheckTest(WriterFunction w, ReaderMemberPtr r, V value)
+void WriteAndReadRapidCheckTest(WriterFunction w, ReaderMemberPtr r, V value)
 {
 	Writer writer;
 	std::array<uint8_t, sizeof(V)> array;
@@ -29,47 +24,47 @@ void WriterReaderRapidCheckTest(WriterFunction w, ReaderMemberPtr r, V value)
 	RC_ASSERT(reader.RemainingSize() == 0);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, Byte, (uint8_t value))
+RC_GTEST_PROP(WriteAndRead, Byte, (uint8_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteByte, &Reader::ReadByte, value);
+	WriteAndReadRapidCheckTest(WriterWriteByte, &Reader::ReadByte, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, WordLE, (uint16_t value))
+RC_GTEST_PROP(WriteAndRead, WordLE, (uint16_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteWordLE, &Reader::ReadWordLE, value);
+	WriteAndReadRapidCheckTest(WriterWriteWordLE, &Reader::ReadWordLE, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, SignedWordLE, (int16_t value))
+RC_GTEST_PROP(WriteAndRead, SignedWordLE, (int16_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteSignedWordLE, &Reader::ReadSignedWordLE, value);
+	WriteAndReadRapidCheckTest(WriterWriteSignedWordLE, &Reader::ReadSignedWordLE, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, DoubleWordLE, (uint32_t value))
+RC_GTEST_PROP(WriteAndRead, DoubleWordLE, (uint32_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteDoubleWordLE, &Reader::ReadDoubleWordLE, value);
+	WriteAndReadRapidCheckTest(WriterWriteDoubleWordLE, &Reader::ReadDoubleWordLE, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, SignedDoubleWordLE, (int32_t value))
+RC_GTEST_PROP(WriteAndRead, SignedDoubleWordLE, (int32_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteSignedDoubleWordLE, &Reader::ReadSignedDoubleWordLE, value);
+	WriteAndReadRapidCheckTest(WriterWriteSignedDoubleWordLE, &Reader::ReadSignedDoubleWordLE, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, QuadWordLE, (uint64_t value))
+RC_GTEST_PROP(WriteAndRead, QuadWordLE, (uint64_t value))
 {
-	WriterReaderRapidCheckTest(WriterWriteQuadWordLE, &Reader::ReadQuadWordLE, value);
+	WriteAndReadRapidCheckTest(WriterWriteQuadWordLE, &Reader::ReadQuadWordLE, value);
 }
 
-RC_GTEST_PROP(WriteReadRapicheck, Array, (std::vector<uint8_t> value))
+RC_GTEST_PROP(WriteAndRead, Array, (std::vector<uint8_t> value))
 {
 	RC_PRE(value.size() > 0u);
-	std::unique_ptr<uint8_t[]> array(new uint8_t[value.size()]);
+	std::vector<uint8_t> array(value.size());
 
 	Writer writer;
-	WriterInitialize(&writer, array.get(), value.size());
+	WriterInitialize(&writer, array.data(), array.size());
 	RC_ASSERT(WriterWriteArray(&writer, value.data(), value.size()));
 	RC_ASSERT(WriterStatus(&writer));
 
-	Reader reader{gsl::make_span(array.get(), value.size())};
+	Reader reader{array};
 	auto read = reader.ReadArray(value.size());
 	for(size_t i = 0; i < value.size(); ++i)
 	{

--- a/unit_tests/base/RapidTest.cpp
+++ b/unit_tests/base/RapidTest.cpp
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "rapidcheck.hpp"
+#include "rapidcheck/gtest.h"
+
+#include "system.h"
+#include "base/reader.h"
+#include "base/writer.h"
+
+using testing::Eq;
+using testing::ElementsAre;
+
+
+template<typename WriterFunction, typename ReaderMemberPtr, typename V>
+void WriterReaderRapidCheckTest(WriterFunction w, ReaderMemberPtr r, V value)
+{
+	Writer writer;
+	std::array<uint8_t, sizeof(V)> array;
+
+	WriterInitialize(&writer, array.begin(), array.size());
+	RC_ASSERT(w(&writer, value));
+	RC_ASSERT(WriterStatus(&writer));
+	RC_ASSERT(WriterRemainingSize(&writer) == 0);
+
+	Reader reader{gsl::make_span(array)};
+	V read = (reader.*r)();
+	RC_ASSERT(read == value);
+	RC_ASSERT(reader.Status());
+	RC_ASSERT(reader.RemainingSize() == 0);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, Byte, (uint8_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteByte, &Reader::ReadByte, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, WordLE, (uint16_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteWordLE, &Reader::ReadWordLE, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, SignedWordLE, (int16_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteSignedWordLE, &Reader::ReadSignedWordLE, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, DoubleWordLE, (uint32_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteDoubleWordLE, &Reader::ReadDoubleWordLE, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, SignedDoubleWordLE, (int32_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteSignedDoubleWordLE, &Reader::ReadSignedDoubleWordLE, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, QuadWordLE, (uint64_t value))
+{
+	WriterReaderRapidCheckTest(WriterWriteQuadWordLE, &Reader::ReadQuadWordLE, value);
+}
+
+RC_GTEST_PROP(WriteReadRapicheck, Array, (std::vector<uint8_t> value))
+{
+	RC_PRE(value.size() > 0u);
+	std::unique_ptr<uint8_t[]> array(new uint8_t[value.size()]);
+
+	Writer writer;
+	WriterInitialize(&writer, array.get(), value.size());
+	RC_ASSERT(WriterWriteArray(&writer, value.data(), value.size()));
+	RC_ASSERT(WriterStatus(&writer));
+
+	Reader reader{gsl::make_span(array.get(), value.size())};
+	auto read = reader.ReadArray(value.size());
+	for(size_t i = 0; i < value.size(); ++i)
+	{
+		RC_ASSERT(read[i] == value[i]);
+	}
+	RC_ASSERT(reader.Status());
+	RC_ASSERT(reader.RemainingSize() == 0);
+}

--- a/unit_tests/base/ReaderTest.cpp
+++ b/unit_tests/base/ReaderTest.cpp
@@ -103,6 +103,26 @@ TEST(ReaderTest, TestReadingWordLE)
     ASSERT_TRUE(reader.Status());
 }
 
+TEST(ReaderTest, TestReadingSignedWordLE)
+{
+    uint8_t array[] = {0x00, 0x00,
+                       0xFF, 0xFF,
+                       0xFF, 0x7F,
+                       0x00, 0x80,
+                       0x68, 0xC5,
+                       0x98, 0x3A};
+    Reader reader;
+    reader.Initialize(array);
+    
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(0));
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(-1));
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(32767));
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(-32768));
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(-15000));
+    ASSERT_THAT(reader.ReadSignedWordLE(), Eq(15000));
+    ASSERT_TRUE(reader.Status());
+}
+
 TEST(ReaderTest, TestReadingWordBE)
 {
     Reader reader;
@@ -140,6 +160,31 @@ TEST(ReaderTest, TestReadingDWordLE)
 
     reader.Initialize(array);
     ASSERT_THAT(reader.ReadDoubleWordLE(), Eq(0xEE77AA55U));
+    ASSERT_TRUE(reader.Status());
+}
+
+TEST(ReaderTest, TestReadingSignedDWordLE)
+{
+    uint8_t array[] = {0x0, 0x0, 0x0, 0x0,
+                       0xFF, 0xFF, 0xFF, 0xFF,
+                       0xFF, 0x7F, 0x0, 0x0,
+                       0x0, 0x80, 0xFF, 0xFF,
+                       0xFF, 0xFF, 0xFF, 0x7F,
+                       0x0, 0x0, 0x0, 0x80,
+                       0xD2, 0x2, 0x96, 0x49,
+                       0x2E, 0xFD, 0x69, 0xB6};
+    Reader reader;
+    reader.Initialize(array);
+    
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(0));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(-1));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(32767));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(-32768));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(2147483647));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(-2147483648));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(1234567890));
+    ASSERT_THAT(reader.ReadSignedDoubleWordLE(), Eq(-1234567890));
+
     ASSERT_TRUE(reader.Status());
 }
 

--- a/unit_tests/base/WriterTest.cpp
+++ b/unit_tests/base/WriterTest.cpp
@@ -65,6 +65,29 @@ TEST(WriterTest, TestWritingSingleWordLE)
     CheckBuffer(array, WriterGetDataLength(&writer), expected, sizeof(expected));
 }
 
+TEST(WriterTest, TestWritingSignedSingleWordLE)
+{
+    Writer writer;
+    uint8_t array[12];
+
+    const uint8_t expected[] = {0x00, 0x00,
+                                0xFF, 0xFF,
+                                0xFF, 0x7F,
+                                0x00, 0x80,
+                                0x68, 0xC5,
+                                0x98, 0x3A};
+    WriterInitialize(&writer, array, sizeof(array));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, 0));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, -1));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, 32767));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, -32768));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, -15000));
+    ASSERT_TRUE(WriterWriteSignedWordLE(&writer, 15000));
+
+    ASSERT_TRUE(WriterStatus(&writer));
+    CheckBuffer(array, WriterGetDataLength(&writer), expected, sizeof(expected));
+}
+
 TEST(WriterTest, TestWritingSingleDoubleWordLE)
 {
     Writer writer;
@@ -75,6 +98,32 @@ TEST(WriterTest, TestWritingSingleDoubleWordLE)
     ASSERT_TRUE(WriterStatus(&writer));
     CheckBuffer(array, WriterGetDataLength(&writer), expected, sizeof(expected));
 }
+
+TEST(WriterTest, TestWritingSignedDoubleWordLE)
+{
+    Writer writer;
+    uint8_t array[32];
+    const uint8_t expected[32] = {0x0, 0x0, 0x0, 0x0,
+                                  0xFF, 0xFF, 0xFF, 0xFF,
+                                  0xFF, 0x7F, 0x0, 0x0,
+                                  0x0, 0x80, 0xFF, 0xFF,
+                                  0xFF, 0xFF, 0xFF, 0x7F,
+                                  0x0, 0x0, 0x0, 0x80,
+                                  0xD2, 0x2, 0x96, 0x49,
+                                  0x2E, 0xFD, 0x69, 0xB6};
+    WriterInitialize(&writer, array, sizeof(array));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, 0));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, -1));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, 32767));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, -32768));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, 2147483647));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, -2147483648));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, 1234567890));
+    ASSERT_TRUE(WriterWriteSignedDoubleWordLE(&writer, -1234567890));
+    ASSERT_TRUE(WriterStatus(&writer));
+    CheckBuffer(array, WriterGetDataLength(&writer), expected, sizeof(expected));
+}
+
 
 TEST(WriterTest, TestWritingSingleQuadWordLE)
 {


### PR DESCRIPTION
Added implementation for reader & writer to handle 2's complement little endian 16- and 32-bit values.
Added RapidCheck tests for writer -> reader loop.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/72)
<!-- Reviewable:end -->
