### PR TITLE
Test commands

### DIFF
--- a/integration_tests/devices/__init__.py
+++ b/integration_tests/devices/__init__.py
@@ -14,5 +14,8 @@ __all__ = [
     'TimeoutDevice',
     'AntennaController',
     'PRIMARY_ANTENNA_CONTROLLER_ADDRESS',
-    'BACKUP_ANTENNA_CONTROLLER_ADDRESS'
+    'BACKUP_ANTENNA_CONTROLLER_ADDRESS',
+    'BaudRate',
+    'TransmitterTelemetry',
+    'ReceiverTelemetry'
 ]

--- a/integration_tests/devices/__init__.py
+++ b/integration_tests/devices/__init__.py
@@ -17,5 +17,6 @@ __all__ = [
     'BACKUP_ANTENNA_CONTROLLER_ADDRESS',
     'BaudRate',
     'TransmitterTelemetry',
-    'ReceiverTelemetry'
+    'ReceiverTelemetry',
+    'Antenna',
 ]

--- a/integration_tests/devices/antenna.py
+++ b/integration_tests/devices/antenna.py
@@ -9,7 +9,17 @@ class Antenna(object):
     def __init__(self):
         self.deployed = False
         self.activation_count = 0
+        self.activation_time = 0
         self.is_being_deployed = False
+
+    @staticmethod
+    def build(deployed, activation_count, activation_time, deployInProgress):
+        value = Antenna()
+        value.deployed = deployed
+        value.activation_count = activation_count
+        value.activation_time = activation_time
+        value.is_being_deployed = deployInProgress
+        return value
 
     def deployment_in_progress(self):
         return self.is_being_deployed
@@ -58,7 +68,7 @@ class AntennaController(i2cMock.I2CDevice):
         # controller reference to the controller object that is being affected
         # antennaId Identifier of the antenna whose deployment process is being deployed. 
         #   Antenna ids have positive ids, value -1 indicates automatic deployment.
-        # this callback can return bool indicating whether the deployment process state. 
+        # this callback can return bool indicating new deployment process state. 
         # True for the antenna being currently deployed, false in case the deployment process
         # should not start. Returning None will indicate that default behaviour should be used.
         self.on_begin_deployment = None
@@ -96,8 +106,8 @@ class AntennaController(i2cMock.I2CDevice):
     @i2cMock.command([0xAA])
     def reset(self):
         self.log.debug("Resetting antenna controller")
-        self.reset_state()
-        call(self.on_reset, None)
+        if(call(self.on_reset, True)):
+            self.reset_state()
 
     # antenna icd section 6.2.2
     @i2cMock.command([0xAD])
@@ -168,8 +178,9 @@ class AntennaController(i2cMock.I2CDevice):
         self.log.debug("Beginning automatic antenna deployment on controller")
         self.deployment_in_progress = call(self.on_begin_deployment, True, self, -1)
 
-    def get_antenna_activation_count(self, antenna_id):
+    def _get_antenna_activation_count(self, antenna_id):
         return [self.antenna_state[antenna_id - 1].activation_count]
+
 
     # antenna icd section 6.2.16
     @i2cMock.command([0xB0])
@@ -191,31 +202,35 @@ class AntennaController(i2cMock.I2CDevice):
     def _get_antenna_4_activation_count(self):
         return self._get_antenna_activation_count(4)
 
+    def _get_activation_time(self, antennaId):
+        time = self.antenna_state[antennaId].activation_time
+        return [higher_byte(time), lower_byte(time)]
+
     # antenna icd section 6.2.20
     @i2cMock.command([0xB4])
     def _get_antenna_1_activation_time(self):
-        return [0, 0]
+        return self._get_activation_time(0)
 
     # antenna icd section 6.2.21
     @i2cMock.command([0xB5])
     def _get_antenna_2_activation_time(self):
-        return [0, 0]
+        return self._get_activation_time(1)
 
     # antenna icd section 6.2.22
     @i2cMock.command([0xB6])
     def _get_antenna_3_activation_time(self):
-        return [0, 0]
+        return self._get_activation_time(2)
 
     # antenna icd section 6.2.23
     @i2cMock.command([0xB7])
     def _get_antenna_4_activation_time(self):
-        return [0, 0]
+        return self._get_activation_time(3)
 
     # antenna icd section 6.2.14
     @i2cMock.command([0xC0])
     def _get_temperature(self):
-        result = call(self.on_get_temperature, None) or 0
-        return [(result >> 8) & 0xff, result & 0xff]
+        result = call(self.on_get_temperature, 0)
+        return [higher_byte(result), lower_byte(result)]
 
     @staticmethod
     def update_value(value, condition, flag):

--- a/integration_tests/devices/antenna.py
+++ b/integration_tests/devices/antenna.py
@@ -106,7 +106,7 @@ class AntennaController(i2cMock.I2CDevice):
     @i2cMock.command([0xAA])
     def reset(self):
         self.log.debug("Resetting antenna controller")
-        if(call(self.on_reset, True)):
+        if call(self.on_reset, True):
             self.reset_state()
 
     # antenna icd section 6.2.2

--- a/integration_tests/devices/comm.py
+++ b/integration_tests/devices/comm.py
@@ -126,11 +126,43 @@ class TransmitterDevice(i2cMock.I2CDevice):
     def __init__(self):
         super(TransmitterDevice, self).__init__(0x62)
         self.log = logging.getLogger("Comm Transmitter")
+
+        # callback called when watchdog is being reset
+        # expected prototype:
+        # None -> None
         self.on_watchdog_reset = None
+
+        # callback called when hardware reset is being invoked 
+        # expected prototype:
+        # None -> None
         self.on_hardware_reset = None
+
+        # callback called when hardware reset is being invoked 
+        # expected prototype:
+        # None -> None
         self.on_reset = None
+
+        # callback called when new frame is being sent
+        # expected prototype:
+        # byte[] frameContent -> None
+        # parameters:
+        # frameContent byte array that contains frame content
         self.on_send_frame = None
+
+        # callback called when new transmitter baud rate is being set
+        # expected prototype:
+        # BaudRate newBaudRate -> BaudRate|None
+        # parameters:
+        # newBaudRate requested new transmitter baud rate
+        # This callback can override the requested baud rate by returning its own the desired value. 
+        # Returning none indicates that requested baud rate should be used.
         self.on_set_baudrate = None
+
+        # callback called when transmitter telemetry is being requested
+        # expected prototype:
+        # None -> TransmitterTelemetry|None
+        # This callback can override the telemetry retuned by this device by returning the desired response.
+        # Returning None will indicate that default telemetry should be reported.
         self.on_get_telemetry = None
         self._buffer = Queue(TransmitterDevice.BUFFER_SIZE)
         self._lock = Lock()
@@ -183,11 +215,45 @@ class ReceiverDevice(i2cMock.I2CDevice):
     def __init__(self):
         super(ReceiverDevice, self).__init__(0x60)
         self.log = logging.getLogger("Comm Receiver")
+
+        # callback called when watchdog is being reset
+        # expected prototype:
+        # None -> None
         self.on_watchdog_reset = None
+
+        # callback called when hardware reset is being invoked 
+        # expected prototype:
+        # None -> None
         self.on_hardware_reset = None
+
+        # callback called when hardware reset is being invoked 
+        # expected prototype:
+        # None -> None
         self.on_reset = None
+
+        # callback called when frame is being removed from the frame buffer
+        # expected prototype:
+        # ReceiverDevice device -> bool|None
+        # parameters:
+        # device Reference to the affected device
+        # This callback can return bool indicating whether frame should be removed from the buffer.
+        # Returning True|None will indicate that frame should be remove from the buffer.
         self.on_frame_remove = None
+
+        # callback called when frame content is being requested
+        # expected prototype:
+        # ReceiverDevice device -> bool|None
+        # parameters:
+        # device Reference to the affected device
+        # This callback can return bool indicating whether non empty frame should be obtained from the buffer.
+        # Returning True|None will indicate that non empty frame should be returned if it is available.
         self.on_frame_receive = None
+
+        # callback called when receiver telemetry is being requested
+        # expected prototype:
+        # None -> ReceiverTelemetry|None
+        # This callback can override the telemetry retuned by this device by returning the desired response.
+        # Returning None will indicate that default telemetry should be reported.
         self.on_get_telemetry = None
         self._buffer = Queue()
         self._lock = Lock()
@@ -271,8 +337,19 @@ class Comm(object):
     def __init__(self):
         self.transmitter = TransmitterDevice()
         self.receiver = ReceiverDevice()
+
+        # callback called when hardware reset is being invoked 
+        # expected prototype:
+        # None -> bool|None
+        # This callback can return bool value indicating whether the hardware reset should be performed.
+        # Returning True/None indicates that hardware reset should be performed.
         self.on_hardware_reset = None
+
+        # callback called when watchdog is being reset
+        # expected prototype:
+        # None -> None
         self.on_watchdog_reset = None
+
         self.transmitter.on_hardware_reset = self._hwreset
         self.transmitter.on_watchdog_reset = self._watchdog_reset
         self.receiver.on_hardware_reset = self._hwreset

--- a/integration_tests/i2cMock/i2cMock.py
+++ b/integration_tests/i2cMock/i2cMock.py
@@ -53,7 +53,7 @@ class I2CDevice(object):
         self.freeze_end.wait()
 
     def _missing_handler(self, data):
-        logging.getLogger('Device.{:2X}'.format(self.address)).error('Missing handler for {}'.format(self.address, binascii.hexlify(bytearray(data))))
+        logging.getLogger('Device: 0x{:2X}'.format(self.address)).error('Missing handler for 0x{:2X}'.format(self.address, binascii.hexlify(bytearray(data))))
 
     def _init_handlers(self):
         handlers = []
@@ -70,11 +70,11 @@ class I2CDevice(object):
 class MissingDevice(I2CDevice):
     def __init__(self, address):
         super(MissingDevice, self).__init__(address)
-        self._log = logging.getLogger('MissingDevice.{:2X}'.format(address))
+        self._log = logging.getLogger('MissingDevice: 0x{:2X}'.format(address))
 
     @command([])
     def catch_all(self, *data):
-        self._log.error('Missing handler for {}'.format(self.address, binascii.hexlify(bytearray(data))))
+        self._log.error('Missing handler for 0x{}'.format(self.address, binascii.hexlify(bytearray(data))))
         return [0xCC]
 
 

--- a/integration_tests/obc/__init__.py
+++ b/integration_tests/obc/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     'AntennaChannel',
     'OverrideSwitches',
     'CommModule',
+    'AntennaTelemetry'
 ]

--- a/integration_tests/obc/antenna.py
+++ b/integration_tests/obc/antenna.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum, unique
 from .obc_mixin import OBCMixin, command, decode_return
 
@@ -54,6 +55,12 @@ class AntennaStatus:
         self.SystemArmed = False
         self.IgnoringSwitches = False
 
+class AntennaTelemetry(object):
+    def __init__(self):
+        self.ActivationCount = [0, 0, 0, 0]
+        self.ActivationTime = [0, 0, 0, 0]
+        self.Temperature = [0, 0]
+
 class AntennaMixin(OBCMixin):
     def __init__(self):
         pass
@@ -83,4 +90,32 @@ class AntennaMixin(OBCMixin):
     @decode_return(_parse_deployment_state)
     @command("antenna_get_status {0}")
     def antenna_get_status(self, channel):
+        pass
+
+    @staticmethod
+    def extract_value(string):
+        m = re.search('([^:]+):\ *\'(\w+)\'', string)
+        if(m.group(2) == "Unavailable"):
+            return None
+        else:
+            return int(m.group(2))
+
+    def _parse_telemetry(result):
+        telemetry = AntennaTelemetry()
+        parts = result.split("\n")
+        telemetry.ActivationCount[0] = AntennaMixin.extract_value(parts[0])
+        telemetry.ActivationCount[1] = AntennaMixin.extract_value(parts[1])
+        telemetry.ActivationCount[2] = AntennaMixin.extract_value(parts[2])
+        telemetry.ActivationCount[3] = AntennaMixin.extract_value(parts[3])
+        telemetry.ActivationTime[0] = AntennaMixin.extract_value(parts[4])
+        telemetry.ActivationTime[1] = AntennaMixin.extract_value(parts[5])
+        telemetry.ActivationTime[2] = AntennaMixin.extract_value(parts[6])
+        telemetry.ActivationTime[3] = AntennaMixin.extract_value(parts[7])
+        telemetry.Temperature[0] = AntennaMixin.extract_value(parts[8])
+        telemetry.Temperature[1] = AntennaMixin.extract_value(parts[9])
+        return telemetry
+
+    @decode_return(_parse_telemetry)
+    @command("antenna_get_telemetry")
+    def antenna_get_telemetry(self):
         pass

--- a/integration_tests/tests/test_comm.py
+++ b/integration_tests/tests/test_comm.py
@@ -1,11 +1,8 @@
-import struct
-
-from build_config import config
-from tests.base import BaseTest
-from system import auto_comm_handling, auto_power_on
-from utils import TestEvent
-from obc import *
 from devices import *
+from obc import *
+from tests.base import BaseTest
+from system import auto_power_on
+from utils import TestEvent, ensure_byte_list
 
 class Test_Comm(BaseTest):
     @auto_power_on(False)
@@ -98,7 +95,7 @@ class Test_Comm(BaseTest):
         self.system.comm.receiver.on_reset = reset_handler
         self.power_on_and_wait()
 
-        self.system.comm.put_frame(devices.UplinkFrame(ord('P'), 'ABC'))
+        self.system.comm.put_frame(UplinkFrame(ord('P'), 'ABC'))
 
         msg = self.system.comm.get_frame(20)
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -19,6 +19,12 @@ def pad_to_multiply(s, base):
 def b64pad(s):
     return pad_to_multiply(s, 3, '=')
 
+def lower_byte(value):
+    return value & 0xff
+
+def higher_byte(value):
+    return (value >> 8) & 0xff
+
 class ExtendableFormatter(Formatter):
     _converters = {}
 

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -60,7 +60,7 @@ static bool GetAntenna(const char* name, AntennaId* antenna)
     return true;
 }
 
-void AntennaDeploy(uint16_t argc, char* argv[])
+void AntennaDeploy(std::uint16_t argc, char* argv[])
 {
     AntennaChannel channel;
     AntennaId antenna;
@@ -85,7 +85,7 @@ void AntennaDeploy(uint16_t argc, char* argv[])
     return;
 }
 
-void AntennaCancelDeployment(uint16_t argc, char* argv[])
+void AntennaCancelDeployment(std::uint16_t argc, char* argv[])
 {
     AntennaChannel channel;
     if (                               //
@@ -100,7 +100,7 @@ void AntennaCancelDeployment(uint16_t argc, char* argv[])
     Main.antennaDriver.FinishDeployment(&Main.antennaDriver, channel);
 }
 
-void AntennaGetDeploymentStatus(uint16_t argc, char* argv[])
+void AntennaGetDeploymentStatus(std::uint16_t argc, char* argv[])
 {
     AntennaChannel channel;
     if (                               //
@@ -148,7 +148,7 @@ void PrintValue(int value, bool print, const char* name)
     }
 }
 
-void AntennaGetTelemetry(uint16_t /*argc*/, char* /*argv*/ [])
+void AntennaGetTelemetry(std::uint16_t /*argc*/, char* /*argv*/ [])
 {
     auto telemetry = Main.antennaDriver.GetTelemetry(&Main.antennaDriver);
     PrintValue(telemetry.ActivationCount[0], has_flag(telemetry.flags, ANT_TM_ANTENNA1_ACTIVATION_COUNT), "Antenna 1 activation count");
@@ -169,7 +169,7 @@ void AntennaGetTelemetry(uint16_t /*argc*/, char* /*argv*/ [])
     PrintValue(telemetry.Temperature[1], has_flag(telemetry.flags, ANT_TM_TEMPERATURE2), "Backup controller temperature");
 }
 
-void AntennaReset(uint16_t argc, char* argv[])
+void AntennaReset(std::uint16_t argc, char* argv[])
 {
     AntennaChannel channel;
     if (argc != 1 || !GetChannel(argv[0], &channel))
@@ -185,6 +185,6 @@ void AntennaReset(uint16_t argc, char* argv[])
     }
     else
     {
-        Main.terminal.Printf("Unable to reset antenna. Status: '%d'", result);
+        Main.terminal.Printf("Unable to reset antenna. Status: '%d'", num(result));
     }
 }

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -135,3 +135,56 @@ void AntennaGetDeploymentStatus(uint16_t argc, char* argv[])
             );
     }
 }
+
+void PrintValue(int value, bool print, const char* name)
+{
+    if (print)
+    {
+        Main.terminal.Printf("%s: '%d'", name, value);
+    }
+    else
+    {
+        Main.terminal.Printf("%s: Unavailable", name);
+    }
+}
+
+void AntennaGetTelemetry(uint16_t /*argc*/, char* /*argv*/ [])
+{
+    auto telemetry = Main.antennaDriver.GetTelemetry(&Main.antennaDriver);
+    PrintValue(telemetry.ActivationCount[0], has_flag(telemetry.flags, ANT_TM_ANTENNA1_ACTIVATION_COUNT), "Antenna 1 activation count");
+    PrintValue(telemetry.ActivationCount[1], has_flag(telemetry.flags, ANT_TM_ANTENNA2_ACTIVATION_COUNT), "Antenna 2 activation count");
+    PrintValue(telemetry.ActivationCount[2], has_flag(telemetry.flags, ANT_TM_ANTENNA3_ACTIVATION_COUNT), "Antenna 3 activation count");
+    PrintValue(telemetry.ActivationCount[3], has_flag(telemetry.flags, ANT_TM_ANTENNA4_ACTIVATION_COUNT), "Antenna 4 activation count");
+
+    PrintValue(
+        telemetry.ActivationTime[0].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA1_ACTIVATION_TIME), "Antenna 1 activation count");
+    PrintValue(
+        telemetry.ActivationTime[1].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA2_ACTIVATION_TIME), "Antenna 2 activation count");
+    PrintValue(
+        telemetry.ActivationTime[2].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA3_ACTIVATION_TIME), "Antenna 3 activation count");
+    PrintValue(
+        telemetry.ActivationTime[3].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA4_ACTIVATION_TIME), "Antenna 4 activation count");
+
+    PrintValue(telemetry.Temperature[0], has_flag(telemetry.flags, ANT_TM_TEMPERATURE1), "Primary controller temperature");
+    PrintValue(telemetry.Temperature[1], has_flag(telemetry.flags, ANT_TM_TEMPERATURE2), "Backup controller temperature");
+}
+
+void AntennaReset(uint16_t argc, char* argv[])
+{
+    AntennaChannel channel;
+    if (argc != 1 || !GetChannel(argv[0], &channel))
+    {
+        Main.terminal.Puts("antenna_reset [primary|backup]\n");
+        return;
+    }
+
+    const OSResult result = Main.antennaDriver.Reset(&Main.antennaDriver, channel);
+    if (OS_RESULT_SUCCEEDED(result))
+    {
+        Main.terminal.Puts("Done");
+    }
+    else
+    {
+        Main.terminal.Printf("Unable to reset antenna. Status: '%d'", result);
+    }
+}

--- a/src/commands/antenna.cpp
+++ b/src/commands/antenna.cpp
@@ -140,11 +140,11 @@ void PrintValue(int value, bool print, const char* name)
 {
     if (print)
     {
-        Main.terminal.Printf("%s: '%d'", name, value);
+        Main.terminal.Printf("%s: '%d'\n", name, value);
     }
     else
     {
-        Main.terminal.Printf("%s: Unavailable", name);
+        Main.terminal.Printf("%s: 'Unavailable'\n", name);
     }
 }
 
@@ -157,13 +157,13 @@ void AntennaGetTelemetry(uint16_t /*argc*/, char* /*argv*/ [])
     PrintValue(telemetry.ActivationCount[3], has_flag(telemetry.flags, ANT_TM_ANTENNA4_ACTIVATION_COUNT), "Antenna 4 activation count");
 
     PrintValue(
-        telemetry.ActivationTime[0].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA1_ACTIVATION_TIME), "Antenna 1 activation count");
+        telemetry.ActivationTime[0].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA1_ACTIVATION_TIME), "Antenna 1 activation time");
     PrintValue(
-        telemetry.ActivationTime[1].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA2_ACTIVATION_TIME), "Antenna 2 activation count");
+        telemetry.ActivationTime[1].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA2_ACTIVATION_TIME), "Antenna 2 activation time");
     PrintValue(
-        telemetry.ActivationTime[2].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA3_ACTIVATION_TIME), "Antenna 3 activation count");
+        telemetry.ActivationTime[2].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA3_ACTIVATION_TIME), "Antenna 3 activation time");
     PrintValue(
-        telemetry.ActivationTime[3].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA4_ACTIVATION_TIME), "Antenna 4 activation count");
+        telemetry.ActivationTime[3].count(), has_flag(telemetry.flags, ANT_TM_ANTENNA4_ACTIVATION_TIME), "Antenna 4 activation time");
 
     PrintValue(telemetry.Temperature[0], has_flag(telemetry.flags, ANT_TM_TEMPERATURE1), "Primary controller temperature");
     PrintValue(telemetry.Temperature[1], has_flag(telemetry.flags, ANT_TM_TEMPERATURE2), "Backup controller temperature");

--- a/src/commands/comm.cpp
+++ b/src/commands/comm.cpp
@@ -12,7 +12,7 @@
 using std::uint16_t;
 using std::uint8_t;
 using gsl::span;
-using devices::comm::Frame;
+using namespace devices::comm;
 
 void SendFrameHandler(uint16_t argc, char* argv[])
 {
@@ -40,7 +40,7 @@ void ReceiveFrameHandler(uint16_t argc, char* argv[])
     UNREFERENCED_PARAMETER(argv);
     LOG(LOG_LEVEL_INFO, "Received request to get the oldes frame from comm...");
     Frame frame;
-    std::uint8_t buffer[devices::comm::PrefferedBufferSize];
+    std::uint8_t buffer[PrefferedBufferSize];
     if (!Main.Communication.CommDriver.ReceiveFrame(buffer, frame))
     {
         LOG(LOG_LEVEL_ERROR, "Unable to get frame from comm. ");
@@ -114,6 +114,97 @@ void CommReset(uint16_t argc, char* argv[])
     else
     {
         Main.Communication.CommDriver.ResetWatchdogReceiver();
+    }
+}
+
+void CommGetTelemetry(uint16_t argc, char* argv[])
+{
+    int channel;
+    if (argc != 1 || !GetHardware(argv[0], channel) || (channel != 1 && channel != 2))
+    {
+        Main.terminal.Puts("comm_get_telemetry [transmitter|receiver]");
+        return;
+    }
+
+    if (channel == 1)
+    {
+        TransmitterTelemetry telemetry;
+        if (!Main.Communication.CommDriver.GetTransmitterTelemetry(telemetry))
+        {
+            Main.terminal.Puts("Unable to get transmitter telemetry");
+            return;
+        }
+
+        Main.terminal.Printf(
+            "RFReflectedPower: '%d'\nAmplifierTemperature: '%d'\nRFForwardPower: '%d'\nTransmitterCurrentConsumption: '%d'",
+            static_cast<int>(telemetry.RFReflectedPower),
+            static_cast<int>(telemetry.AmplifierTemperature),
+            static_cast<int>(telemetry.RFForwardPower),
+            static_cast<int>(telemetry.TransmitterCurrentConsumption));
+    }
+    else
+    {
+        ReceiverTelemetry telemetry;
+        if (!Main.Communication.CommDriver.GetReceiverTelemetry(telemetry))
+        {
+            Main.terminal.Puts("Unable to get receiver telemetry");
+            return;
+        }
+
+        Main.terminal.Printf("TransmitterCurrentConsumption: '%d'\nReceiverCurrentConsumption: '%d'\nDopplerOffset: '%d'\nVcc: "
+                             "'%d'\nOscilatorTemperature: '%d'\nAmplifierTemperature: '%d'\nSignalStrength: '%d'",
+            static_cast<int>(telemetry.TransmitterCurrentConsumption),
+            static_cast<int>(telemetry.ReceiverCurrentConsumption),
+            static_cast<int>(telemetry.DopplerOffset),
+            static_cast<int>(telemetry.Vcc),
+            static_cast<int>(telemetry.OscilatorTemperature),
+            static_cast<int>(telemetry.AmplifierTemperature),
+            static_cast<int>(telemetry.SignalStrength));
+    }
+}
+
+static bool GetBitRate(const char* name, Bitrate& bitRate)
+{
+    if (strcmp(name, "1200") == 0)
+    {
+        bitRate = Bitrate::Comm1200bps;
+        return true;
+    }
+    else if (strcmp(name, "2400") == 0)
+    {
+        bitRate = Bitrate::Comm2400bps;
+        return true;
+    }
+    else if (strcmp(name, "4800") == 0)
+    {
+        bitRate = Bitrate::Comm4800bps;
+        return true;
+    }
+    else if (strcmp(name, "9600") == 0)
+    {
+        bitRate = Bitrate::Comm9600bps;
+        return true;
+    }
+
+    return false;
+}
+
+void CommSetBaudRate(uint16_t argc, char* argv[])
+{
+    Bitrate bitRate;
+    if (argc != 1 || !GetBitRate(argv[0], bitRate))
+    {
+        Main.terminal.Puts("comm_set_bitrate [1200|2400|4800|9600]");
+        return;
+    }
+
+    if (Main.Communication.CommDriver.SetTransmitterBitRate(bitRate))
+    {
+        Main.terminal.Puts("Done");
+    }
+    else
+    {
+        Main.terminal.Printf("Unable to set bit rate to: '%d'.", static_cast<int>(bitRate));
     }
 }
 

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -12,9 +12,9 @@ void SendFrameHandler(std::uint16_t argc, char* argv[]);
 void GetFramesCountHandler(std::uint16_t argc, char* argv[]);
 void ReceiveFrameHandler(std::uint16_t argc, char* argv[]);
 void CommandPauseComm(std::uint16_t argc, char* argv[]);
-void CommReset(uint16_t argc, char* argv[]);
-void CommGetTelemetry(uint16_t argc, char* argv[]);
-void CommSetBaudRate(uint16_t argc, char* argv[]);
+void CommReset(std::uint16_t argc, char* argv[]);
+void CommGetTelemetry(std::uint16_t argc, char* argv[]);
+void CommSetBaudRate(std::uint16_t argc, char* argv[]);
 void OBCGetState(std::uint16_t argc, char* argv[]);
 void FSListFiles(std::uint16_t argc, char* argv[]);
 void FSWriteFile(std::uint16_t argc, char* argv[]);
@@ -30,10 +30,10 @@ void HeapInfoCommand(std::uint16_t argc, char* argv[]);
 void AntennaDeploy(std::uint16_t argc, char* argv[]);
 void AntennaCancelDeployment(std::uint16_t argc, char* argv[]);
 void AntennaGetDeploymentStatus(std::uint16_t argc, char* argv[]);
-void AntennaGetTelemetry(uint16_t argc, char* argv[]);
-void AntennaReset(uint16_t argc, char* argv[]);
+void AntennaGetTelemetry(std::uint16_t argc, char* argv[]);
+void AntennaReset(std::uint16_t argc, char* argv[]);
 
-void HeapInfo(uint16_t argc, char* argv[]);
+void HeapInfo(std::uint16_t argc, char* argv[]);
 
 void TaskListCommand(std::uint16_t argc, char* argv[]);
 void CompileInfo(std::uint16_t argc, char* argv[]);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -13,6 +13,8 @@ void GetFramesCountHandler(std::uint16_t argc, char* argv[]);
 void ReceiveFrameHandler(std::uint16_t argc, char* argv[]);
 void CommandPauseComm(std::uint16_t argc, char* argv[]);
 void CommReset(uint16_t argc, char* argv[]);
+void CommGetTelemetry(uint16_t argc, char* argv[]);
+void CommSetBaudRate(uint16_t argc, char* argv[]);
 void OBCGetState(std::uint16_t argc, char* argv[]);
 void FSListFiles(std::uint16_t argc, char* argv[]);
 void FSWriteFile(std::uint16_t argc, char* argv[]);
@@ -28,6 +30,8 @@ void HeapInfoCommand(std::uint16_t argc, char* argv[]);
 void AntennaDeploy(std::uint16_t argc, char* argv[]);
 void AntennaCancelDeployment(std::uint16_t argc, char* argv[]);
 void AntennaGetDeploymentStatus(std::uint16_t argc, char* argv[]);
+void AntennaGetTelemetry(uint16_t argc, char* argv[]);
+void AntennaReset(uint16_t argc, char* argv[]);
 
 void HeapInfo(uint16_t argc, char* argv[]);
 

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -35,6 +35,10 @@ static const TerminalCommandDescription commands[] = {
     {"resume_mission", ResumeMission},
     {"run_mission", RunMission},
     {"dma", DMAInfo},
+    {"comm_set_bitrate", CommSetBaudRate},
+    {"comm_get_telemetry", CommGetTelemetry},
+    {"antenna_get_telemetry", AntennaGetTelemetry},
+    {"antenna_reset", AntennaReset},
 };
 
 void InitializeTerminal(void)


### PR DESCRIPTION
Terminal commands for testing comm & antenna hardware/drivers.

* New commands:
   * antenna_get_telemetry
   * antenna_reset [primary|backup]
   * comm_get_telemetry [transmitter|receiver]
   * comm_set_bitrate [1200|2400|4800|9600]
* Some integration tests for new commands
* Extended integration tests documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/73)
<!-- Reviewable:end -->
