### PR TITLE
Changed meaning for I2C adress to 7-bit value

### DIFF
--- a/integration_tests/devices/antenna.py
+++ b/integration_tests/devices/antenna.py
@@ -2,8 +2,8 @@ import logging
 import i2cMock
 from utils import *
 
-PRIMARY_ANTENNA_CONTROLLER_ADDRESS = 0x32
-BACKUP_ANTENNA_CONTROLLER_ADDRESS = 0x34
+PRIMARY_ANTENNA_CONTROLLER_ADDRESS = 0x31
+BACKUP_ANTENNA_CONTROLLER_ADDRESS = 0x32
 
 class Antenna(object):
     def __init__(self):

--- a/integration_tests/devices/comm.py
+++ b/integration_tests/devices/comm.py
@@ -124,7 +124,7 @@ class TransmitterDevice(i2cMock.I2CDevice):
     BUFFER_SIZE = 40
 
     def __init__(self):
-        super(TransmitterDevice, self).__init__(0x62)
+        super(TransmitterDevice, self).__init__(0x61)
         self.log = logging.getLogger("Comm Transmitter")
 
         # callback called when watchdog is being reset

--- a/integration_tests/i2cMock/i2cMock.py
+++ b/integration_tests/i2cMock/i2cMock.py
@@ -143,7 +143,7 @@ class I2CMock(object):
         self._active = True
 
     def add_device(self, device):
-        self._devices[device.address] = device
+        self._devices[2*device.address] = device
 
     def stop(self):
         self._log.debug('Requesting stop')

--- a/libs/drivers/antenna/Include/antenna/antenna.h
+++ b/libs/drivers/antenna/Include/antenna/antenna.h
@@ -37,9 +37,9 @@ enum AntennaId
 enum AntennaChannel
 {
     /** Primary hardware controller address. */
-    ANTENNA_PRIMARY_CHANNEL = 0x32,
+    ANTENNA_PRIMARY_CHANNEL = 0x31,
     /** Backup hardware controller address. */
-    ANTENNA_BACKUP_CHANNEL = 0x34,
+    ANTENNA_BACKUP_CHANNEL = 0x32,
 };
 
 /**

--- a/libs/drivers/comm/Include/comm/comm.hpp
+++ b/libs/drivers/comm/Include/comm/comm.hpp
@@ -206,7 +206,7 @@ enum class TransmitterCommand
 enum class Address
 {
     Receiver = 0x60,
-    Transmitter = 0x62,
+    Transmitter = 0x61,
 };
 
 /** @}*/

--- a/libs/drivers/i2c/Include/i2c/i2c.h
+++ b/libs/drivers/i2c/Include/i2c/i2c.h
@@ -70,7 +70,7 @@ namespace drivers
         /**
          * @brief Type of I2C address.
          *
-         * I2C addresses are 7-bit. Least significant bit is ignored and should be zero.
+         * I2C addresses are 7-bit. Most significant bit have to be '0'.
          */
         using I2CAddress = uint8_t;
 

--- a/libs/drivers/i2c/efm.cpp
+++ b/libs/drivers/i2c/efm.cpp
@@ -1,5 +1,6 @@
 #include <em_cmu.h>
 #include <em_gpio.h>
+#include <cassert>
 
 #include "base/os.h"
 #include "io_map.h"
@@ -66,8 +67,10 @@ I2CResult I2CLowLevelBus::ExecuteTransfer(I2C_TransferSeq_TypeDef* seq)
 
 I2CResult I2CLowLevelBus::Write(const I2CAddress address, gsl::span<const uint8_t> inData)
 {
+    assert((address & 0b10000000) == 0);
+
     I2C_TransferSeq_TypeDef seq;
-    seq.addr = address;
+    seq.addr = (address << 1);
     seq.flags = I2C_FLAG_WRITE;
     seq.buf[0].len = inData.length();
     seq.buf[0].data = const_cast<uint8_t*>(inData.data());
@@ -79,9 +82,10 @@ I2CResult I2CLowLevelBus::Write(const I2CAddress address, gsl::span<const uint8_
 
 I2CResult I2CLowLevelBus::WriteRead(const I2CAddress address, gsl::span<const uint8_t> inData, gsl::span<uint8_t> outData)
 {
-    I2C_TransferSeq_TypeDef seq;
+    assert((address & 0b10000000) == 0);
 
-    seq.addr = address;
+    I2C_TransferSeq_TypeDef seq;
+    seq.addr = (address << 1);
     seq.flags = I2C_FLAG_WRITE_READ;
     seq.buf[0].len = inData.length();
     seq.buf[0].data = const_cast<uint8_t*>(inData.data());

--- a/unit_tests/Comm/CommTest.cpp
+++ b/unit_tests/Comm/CommTest.cpp
@@ -32,7 +32,7 @@ using drivers::i2c::I2CResult;
 using namespace devices::comm;
 
 static constexpr uint8_t ReceiverAddress = 0x60;
-static constexpr uint8_t TransmitterAddress = 0x62;
+static constexpr uint8_t TransmitterAddress = 0x61;
 
 static constexpr uint8_t ReceverGetTelemetry = 0x1A;
 static constexpr uint8_t ReceiverGetFrameCount = 0x21;


### PR DESCRIPTION
After physical tests it turned out that adresses in ICDs are 7-bit value without read/write marker padding.
Therefore, meaning of I2CAdress in I2C interface was changes to reflect 7-bit adress standard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/77)
<!-- Reviewable:end -->
