### PR TITLE
Speed up unit tests compilation

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -31,12 +31,14 @@ set(SOURCES
   MissionPlan/antenna/AntennaMissionStateTest.cpp
   I2C/FallbackI2CBusTest.cpp
   I2C/ErrorHandlingI2CBusTest.cpp
+  I2C/I2CMock.cpp
   N25Q/N25QTest.cpp
   os/TimeoutTest.cpp
   os/EventGroupTest.cpp
   os/os.cpp
   os/os.hpp
   OsMock.hpp
+  OsMock.cpp
   time/time.cpp
   time/timer.cpp
   time/persistance.cpp

--- a/unit_tests/I2C/I2CMock.cpp
+++ b/unit_tests/I2C/I2CMock.cpp
@@ -1,0 +1,9 @@
+#include "I2CMock.hpp"
+
+I2CBusMock::I2CBusMock()
+{
+}
+
+I2CBusMock::~I2CBusMock()
+{
+}

--- a/unit_tests/I2C/I2CMock.hpp
+++ b/unit_tests/I2C/I2CMock.hpp
@@ -8,6 +8,9 @@
 
 struct I2CBusMock : drivers::i2c::II2CBus
 {
+    I2CBusMock();
+    ~I2CBusMock();
+
     MOCK_METHOD2(Write,
         drivers::i2c::I2CResult(const drivers::i2c::I2CAddress address,
             gsl::span<const uint8_t> inData //

--- a/unit_tests/OsMock.cpp
+++ b/unit_tests/OsMock.cpp
@@ -1,0 +1,8 @@
+#include "OsMock.hpp"
+
+OSMock::OSMock()
+{
+}
+OSMock::~OSMock()
+{
+}

--- a/unit_tests/OsMock.hpp
+++ b/unit_tests/OsMock.hpp
@@ -8,6 +8,9 @@
 
 struct OSMock : IOS
 {
+    OSMock();
+    ~OSMock();
+
     MOCK_METHOD6(CreateTask,
         OSResult(OSTaskProcedure entryPoint,
             const char* taskName,

--- a/unit_tests/mock/FsMock.cpp
+++ b/unit_tests/mock/FsMock.cpp
@@ -22,3 +22,11 @@ IOResult MakeFSIOResult(gsl::span<const uint8_t> result)
 {
     return IOResult(OSResult::Success, result);
 }
+
+FsMock::FsMock()
+{
+}
+
+FsMock::~FsMock()
+{
+}

--- a/unit_tests/mock/FsMock.hpp
+++ b/unit_tests/mock/FsMock.hpp
@@ -9,6 +9,9 @@
 
 struct FsMock : services::fs::IFileSystem
 {
+    FsMock();
+    ~FsMock();
+
     MOCK_METHOD3(
         Open, services::fs::FileOpenResult(const char* path, services::fs::FileOpen openFlag, services::fs::FileAccess accessMode));
     MOCK_METHOD2(TruncateFile, OSResult(services::fs::FileHandle file, services::fs::FileSize length));


### PR DESCRIPTION
According to https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#making-the-compilation-faster it is wise to define constructor and destructor of mock class in single .cpp file to speed up compilation.

On my machine, command: `make -C unit_tests clean all -j5`
Before: ~67s
After: ~57s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/87)
<!-- Reviewable:end -->
