### PR TITLE
Fix obc crash after first time update

### DIFF
--- a/libs/drivers/burtc/Include/burtc/burtc.hpp
+++ b/libs/drivers/burtc/Include/burtc/burtc.hpp
@@ -55,7 +55,7 @@ namespace devices
             void ConfigureHardware();
             void StartTask();
 
-            Task<Burtc*, 512_Bytes, TaskPriority::P6> _task;
+            Task<Burtc*, 2_KB, TaskPriority::P6> _task;
 
             /** @brief Calculates current time interval based on selected oscillator frequency, prescaler and compare value **/
             static std::chrono::milliseconds CalculateCurrentTimeInterval();

--- a/platforms/DevBoard/Include/FreeRTOSConfig.h
+++ b/platforms/DevBoard/Include/FreeRTOSConfig.h
@@ -90,6 +90,10 @@ extern void assertFailed(const char* source, const char* file, uint16_t line);
     }
 #endif
 
+#ifdef DEBUG
+#define configCHECK_FOR_STACK_OVERFLOW 2
+#endif
+
 #define configUSE_PREEMPTION 1
 #define configUSE_IDLE_HOOK 1
 #define configUSE_TICK_HOOK 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,12 +45,6 @@ mission::ObcMission Mission(Main.timeProvider, Main.antennaDriver, false, Main.a
 
 const int __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
 
-extern "C" void vApplicationStackOverflowHook(xTaskHandle* pxTask, signed char* pcTaskName)
-{
-    UNREFERENCED_PARAMETER(pxTask);
-    UNREFERENCED_PARAMETER(pcTaskName);
-}
-
 extern "C" void vApplicationIdleHook(void)
 {
     EMU_EnterEM1();


### PR DESCRIPTION
Problem was caused by burtc task stack overflow that  occurred due to time service saving the current time to flash memory a process that requires ~2KB of stack space in total. 

Additionally stack overflow checking has been permanently enabled in debug builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/90)
<!-- Reviewable:end -->
