### PR TITLE
Fixed RTOS errors in Time Provider

### DIFF
--- a/libs/drivers/burtc/Include/burtc/burtc.hpp
+++ b/libs/drivers/burtc/Include/burtc/burtc.hpp
@@ -36,6 +36,11 @@ namespace devices
             OSResult Initialize();
 
             /**
+             * @brief Starts ticking
+             */
+            void Start();
+
+            /**
               * @brief Interrupt handler for BURTC hardware
               */
             void IRQHandler();
@@ -53,7 +58,6 @@ namespace devices
             std::chrono::milliseconds _timeDelta;
 
             void ConfigureHardware();
-            void StartTask();
 
             Task<Burtc*, 2_KB, TaskPriority::P6> _task;
 

--- a/libs/drivers/burtc/burtc.cpp
+++ b/libs/drivers/burtc/burtc.cpp
@@ -20,7 +20,7 @@ void Burtc::IRQHandler()
 {
     std::uint32_t irq = BURTC_IntGet();
     BURTC_IntClear(irq);
-    BURTC_CompareSet(0, BURTC->COMP0 + Burtc::CompareValue);
+    BURTC_CompareSet(0, BURTC_CompareGet(0) + Burtc::CompareValue);
 
     System::GiveSemaphoreISR(burtcInterruptSemaphore);
 
@@ -62,6 +62,13 @@ OSResult Burtc::Initialize()
     return OSResult::Success;
 }
 
+void Burtc::Start()
+{
+    BURTC_CompareSet(0, BURTC_CounterGet() + CompareValue);
+    NVIC_ClearPendingIRQ(BURTC_IRQn);
+    NVIC_EnableIRQ(BURTC_IRQn);
+}
+
 std::chrono::milliseconds Burtc::CalculateCurrentTimeInterval()
 {
     return std::chrono::milliseconds(1000 * CompareValue / BURTC_ClockFreqGet());
@@ -84,10 +91,6 @@ void Burtc::ConfigureHardware()
     BURTC_IntClear(BURTC_IEN_COMP0);
 
     NVIC_SetPriority(BURTC_IRQn, InterruptPriority);
-    NVIC_ClearPendingIRQ(BURTC_IRQn);
-    NVIC_EnableIRQ(BURTC_IRQn);
-
-    BURTC_CompareSet(0, BURTC_CounterGet() + CompareValue);
 
     BURTC_IntEnable(BURTC_IEN_COMP0);
 }

--- a/libs/time/include/time/timer.h
+++ b/libs/time/include/time/timer.h
@@ -296,9 +296,9 @@ namespace services
             struct TimeSnapshot ReadFile(services::fs::IFileSystem& fs, const char* const filePath);
 
           private:
-            static constexpr const char* File0 = "/TimeState.0";
-            static constexpr const char* File1 = "/TimeState.1";
-            static constexpr const char* File2 = "/TimeState.2";
+            static constexpr const char* File0 = "/a/TimeState.0";
+            static constexpr const char* File1 = "/a/TimeState.1";
+            static constexpr const char* File2 = "/a/TimeState.2";
 
             /**
              * @brief Pointer to time notification procedure that gets called on time change.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,8 @@ static void ObcInitTask(void* param)
 
     Mission.Initialize();
 
+    obc->Hardware.Burtc.Start();
+
     System::CreateTask(SmartWaitTask, "SmartWait", 512, NULL, TaskPriority::P1, NULL);
 
     LOG(LOG_LEVEL_INFO, "Intialized");


### PR DESCRIPTION
When external flash is enabled BURTC task tried to invoke time action
before Time Provider was initialized. That caused RTOS assert failures as queue
was not created yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/92)
<!-- Reviewable:end -->
