### PR TITLE
[comm] Prevent beacon update from erasing frames from transmitter queue

### DIFF
--- a/libs/drivers/comm/Include/comm/CommDriver.hpp
+++ b/libs/drivers/comm/Include/comm/CommDriver.hpp
@@ -129,9 +129,10 @@ class CommObject final : public ITransmitFrame, public IBeaconController
      * the beacon itself only if there are no frames that are waiting to te send by the transmitter.
      * @param[in] beacon Reference to object describing new beacon.
      * See the definition of the CommBeacon for details.
-     * @return Operation status, true in case of success, false otherwise.
+     * @return Operation status, true in case of success, false otherwise, None in case there were frames in
+     * transmitter queue.
      */
-    virtual bool SetBeacon(const Beacon& beacon) override final;
+    virtual Option<bool> SetBeacon(const Beacon& beacon) override final;
 
     /**
      * @brief Clears any beacon that is currently set in the transceiver. If a beacon transmission

--- a/libs/drivers/comm/Include/comm/IBeaconController.hpp
+++ b/libs/drivers/comm/Include/comm/IBeaconController.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "comm.hpp"
+#include "utils.h"
 
 COMM_BEGIN
 
@@ -20,7 +21,7 @@ struct IBeaconController
      * See the definition of the CommBeacon for details.
      * @return Operation status, true in case of success, false otherwise.
      */
-    virtual bool SetBeacon(const Beacon& beacon) = 0;
+    virtual Option<bool> SetBeacon(const Beacon& beacon) = 0;
 
     /**
      * @brief Clears any beacon that is currently set in the transceiver. If a beacon transmission

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -321,16 +321,21 @@ bool CommObject::ScheduleFrameTransmission(gsl::span<const std::uint8_t> frame, 
     return status && remainingBufferSize != 0xff;
 }
 
-bool CommObject::SetBeacon(const Beacon& beaconData)
+Option<bool> CommObject::SetBeacon(const Beacon& beaconData)
 {
     std::uint8_t remainingBufferSize = 0;
     const auto result = ScheduleFrameTransmission(beaconData.Contents(), remainingBufferSize);
-    if (!result || remainingBufferSize != (TransmitterBufferSize - 1))
+    if (!result)
     {
-        return false;
+        return Option<bool>::Some(false);
     }
 
-    return UpdateBeacon(beaconData);
+    if (remainingBufferSize != (TransmitterBufferSize - 1))
+    {
+        return Option<bool>::None();
+    }
+
+    return Option<bool>::Some(UpdateBeacon(beaconData));
 }
 
 bool CommObject::UpdateBeacon(const Beacon& beaconData)

--- a/libs/mission/beacon/BeaconUpdate.cpp
+++ b/libs/mission/beacon/BeaconUpdate.cpp
@@ -55,14 +55,20 @@ namespace mission
     void BeaconUpdate::UpdateBeacon(const SystemState& state)
     {
         const auto beacon = GenerateBeacon(state);
-        if (this->controller->SetBeacon(beacon))
+        const auto result = this->controller->SetBeacon(beacon);
+        const auto time = static_cast<std::uint32_t>(duration_cast<seconds>(state.Time).count());
+        if (!result.HasValue)
+        {
+            LOGF(LOG_LEVEL_INFO, "Beacon update rejected at %lu", time);
+        }
+        else if(result.Value)
         {
             this->lastBeaconUpdate = state.Time;
-            LOGF(LOG_LEVEL_INFO, "Beacon set at %lu", static_cast<std::uint32_t>(duration_cast<seconds>(state.Time).count()));
+            LOGF(LOG_LEVEL_INFO, "Beacon set at %lu", time);
         }
         else
         {
-            LOGF(LOG_LEVEL_ERROR, "Unable to set beacon at %lu", static_cast<std::uint32_t>(duration_cast<seconds>(state.Time).count()));
+            LOGF(LOG_LEVEL_ERROR, "Unable to set beacon at %lu", time);
         }
     }
 

--- a/unit_tests/Comm/CommTest.cpp
+++ b/unit_tests/Comm/CommTest.cpp
@@ -611,7 +611,7 @@ TEST_F(CommTest, TestSetBeaconTransmitterBufferNotEmpty)
     std::uint8_t buffer[1];
     Beacon beacon(1s, buffer);
     const auto status = comm.SetBeacon(beacon);
-    ASSERT_THAT(status, Eq(false));
+    ASSERT_THAT(status.HasValue, Eq(false));
 }
 
 TEST_F(CommTest, TestSetBeaconTransmitterBufferFull)
@@ -626,7 +626,7 @@ TEST_F(CommTest, TestSetBeaconTransmitterBufferFull)
     std::uint8_t buffer[1];
     Beacon beacon(1s, buffer);
     const auto status = comm.SetBeacon(beacon);
-    ASSERT_THAT(status, Eq(false));
+    ASSERT_THAT(status.HasValue, Eq(false));
 }
 
 TEST_F(CommTest, TestSetBeaconFailure)

--- a/unit_tests/Comm/CommTest.cpp
+++ b/unit_tests/Comm/CommTest.cpp
@@ -575,20 +575,82 @@ TEST_F(CommTest, TestTransmitterTelemetry)
     ASSERT_THAT(telemetry.TransmitterCurrentConsumption, Eq(0x0807));
 }
 
-TEST_F(CommTest, TestSetBeaconFailure)
+TEST_F(CommTest, TestSetBeaconTransmittFailure)
 {
     std::uint8_t buffer[1];
     Beacon beacon(1s, buffer);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, _, _)).WillOnce(Return(I2CResult::Failure));
+    const auto status = comm.SetBeacon(beacon);
+    ASSERT_THAT(status, Eq(false));
+}
+
+TEST_F(CommTest, TestSetBeaconTransmitterRejected)
+{
+    EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).Times(0);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _))
+        .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> /*inData*/, span<uint8_t> outData) {
+            outData[0] = 0xff;
+            return I2CResult::OK;
+        }));
+
+    std::uint8_t buffer[1];
+    Beacon beacon(1s, buffer);
+    const auto status = comm.SetBeacon(beacon);
+    ASSERT_THAT(status, Eq(false));
+}
+
+TEST_F(CommTest, TestSetBeaconTransmitterBufferNotEmpty)
+{
+    EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).Times(0);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _))
+        .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> /*inData*/, span<uint8_t> outData) {
+            outData[0] = 38;
+            return I2CResult::OK;
+        }));
+
+    std::uint8_t buffer[1];
+    Beacon beacon(1s, buffer);
+    const auto status = comm.SetBeacon(beacon);
+    ASSERT_THAT(status, Eq(false));
+}
+
+TEST_F(CommTest, TestSetBeaconTransmitterBufferFull)
+{
+    EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).Times(0);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _))
+        .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> /*inData*/, span<uint8_t> outData) {
+            outData[0] = 0;
+            return I2CResult::OK;
+        }));
+
+    std::uint8_t buffer[1];
+    Beacon beacon(1s, buffer);
+    const auto status = comm.SetBeacon(beacon);
+    ASSERT_THAT(status, Eq(false));
+}
+
+TEST_F(CommTest, TestSetBeaconFailure)
+{
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _))
+        .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> /*inData*/, span<uint8_t> outData) {
+            outData[0] = 39;
+            return I2CResult::OK;
+        }));
     EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).WillOnce(Return(I2CResult::Nack));
+
+    std::uint8_t buffer[1];
+    Beacon beacon(1s, buffer);
     const auto status = comm.SetBeacon(beacon);
     ASSERT_THAT(status, Eq(false));
 }
 
 TEST_F(CommTest, TestSetBeaconSizeOutOfRange)
 {
+    EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).Times(0);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _)).Times(0);
+
     std::uint8_t buffer[MaxDownlinkFrameSize + 1];
     Beacon beacon(1s, buffer);
-    EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon))).Times(0);
     const auto status = comm.SetBeacon(beacon);
     ASSERT_THAT(status, Eq(false));
 }
@@ -597,6 +659,15 @@ TEST_F(CommTest, TestSetBeacon)
 {
     const uint8_t data[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8};
     Beacon beacon(0x0a0bs, data);
+    EXPECT_CALL(i2c, WriteRead(TransmitterAddress, BeginsWith(TransmitterSendFrame), _))
+        .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> inData, span<uint8_t> outData) {
+            const uint8_t expected[] = {TransmitterSendFrame, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8};
+            EXPECT_THAT(inData, Eq(span<const uint8_t>(expected)));
+
+            outData[0] = 39;
+            return I2CResult::OK;
+        }));
+
     EXPECT_CALL(i2c, Write(TransmitterAddress, BeginsWith(TransmitterSetBeacon)))
         .WillOnce(Invoke([](uint8_t /*address*/, span<const uint8_t> inData) {
             const uint8_t expected[] = {TransmitterSetBeacon, 0x0b, 0x0a, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8};

--- a/unit_tests/MissionPlan/TimeTaskTest.cpp
+++ b/unit_tests/MissionPlan/TimeTaskTest.cpp
@@ -23,8 +23,8 @@ struct TimeTaskTest : public testing::Test
 {
     TimeTaskTest();
 
-    OSMock mock;
-    FsMock fileSystemMock;
+    testing::NiceMock<OSMock> mock;
+    testing::NiceMock<FsMock> fileSystemMock;
     SystemState state;
     TimeProvider provider;
     RtcMock rtc;

--- a/unit_tests/MissionPlan/beacon/BeaconUpdateTest.cpp
+++ b/unit_tests/MissionPlan/beacon/BeaconUpdateTest.cpp
@@ -68,7 +68,7 @@ TEST_F(BeaconUpdateTest, TestBeaconUpdatePeriodAfterSuccessfulUpdate)
     state.Antenna.Deployed = true;
     state.Antenna.DeploymentState[0] = state.Antenna.DeploymentState[1] = true;
     state.Time = 60min;
-    EXPECT_CALL(controller, SetBeacon(_)).WillOnce(Return(true));
+    EXPECT_CALL(controller, SetBeacon(_)).WillOnce(Return(Option<bool>::Some(true)));
     auto action = beacon.BuildAction();
     action.actionProc(state, action.param);
     state.Time = 64min;
@@ -82,7 +82,18 @@ TEST_F(BeaconUpdateTest, TestBeaconUpdatePeriodAfterFailedUpdate)
     state.Antenna.Deployed = true;
     state.Antenna.DeploymentState[0] = state.Antenna.DeploymentState[1] = true;
     state.Time = 60min;
-    EXPECT_CALL(controller, SetBeacon(_)).WillOnce(Return(false));
+    EXPECT_CALL(controller, SetBeacon(_)).WillOnce(Return(Option<bool>::Some(false)));
+    auto action = beacon.BuildAction();
+    action.actionProc(state, action.param);
+    EXPECT_THAT(action.condition(state, action.param), Eq(true));
+}
+
+TEST_F(BeaconUpdateTest, TestBeaconUpdatePeriodAfterRejectedUpdate)
+{
+    state.Antenna.Deployed = true;
+    state.Antenna.DeploymentState[0] = state.Antenna.DeploymentState[1] = true;
+    state.Time = 60min;
+    EXPECT_CALL(controller, SetBeacon(_)).WillOnce(Return(Option<bool>::None()));
     auto action = beacon.BuildAction();
     action.actionProc(state, action.param);
     EXPECT_THAT(action.condition(state, action.param), Eq(true));

--- a/unit_tests/mock/comm.hpp
+++ b/unit_tests/mock/comm.hpp
@@ -17,7 +17,7 @@ struct TransmitFrameMock : public devices::comm::ITransmitFrame
 struct BeaconControllerMock : public devices::comm::IBeaconController
 {
     BeaconControllerMock();
-    MOCK_METHOD1(SetBeacon, bool(const devices::comm::Beacon& beacon));
+    MOCK_METHOD1(SetBeacon, Option<bool>(const devices::comm::Beacon& beacon));
     MOCK_METHOD0(ClearBeacon, bool());
 };
 


### PR DESCRIPTION
Update beacon setting procedure to ensure that setting beacon will not cause
transmitter to remove any frames from the outgoing frame buffer before they
are send. This is done by first sending beacon as a regular frame and checking
the number of transmitter''s output buffer free slot count.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/107)
<!-- Reviewable:end -->
