### PR TITLE
Fix race condition in detumbling experiment test

### DIFF
--- a/integration_tests/tests/test_experiment_detumbling.py
+++ b/integration_tests/tests/test_experiment_detumbling.py
@@ -34,7 +34,7 @@ class TestExperimentDetumbling(BaseTest):
 
         self.system.obc.wait_for_experiment(ExperimentType.Detumbling, 40)
 
-        self.system.obc.advance_time(timedelta(hours=4).total_seconds() * 1000)
-        self.system.rtc.set_response_time(start_time + timedelta(hours=4))
+        self.system.obc.advance_time(timedelta(hours=4, minutes=1).total_seconds() * 1000)
+        self.system.rtc.set_response_time(start_time + timedelta(hours=4, minutes=1))
 
         self.system.obc.wait_for_experiment(None, 20)


### PR DESCRIPTION
In detumbling experiment test, experiment was commanded to run for 4
hours. After that OBC time was advanced also by 4 hours, however it was
not enough as during next mission loop OBC time was few milliseconds
before scheduled experiment end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/119)
<!-- Reviewable:end -->
