### PR TITLE
No busy waiting for OBC startup

### DIFF
--- a/integration_tests/obc/obc.py
+++ b/integration_tests/obc/obc.py
@@ -1,19 +1,17 @@
+from datetime import datetime
 import logging
 from base64 import b64encode
 
-import time
-
 from utils import ExtendableFormatter
-
-from .experiments import ExperimentsMixin
-from .obc_mixin import OBCMixin
-from .file_system import FileSystemMixin
 from .antenna import AntennaMixin
 from .comm import CommMixin
-from .obc_time import TimeMixin
+from .experiments import ExperimentsMixin
+from .file_system import FileSystemMixin
 from .i2c import I2CMixin
-from .mission import MissionMixin
 from .imtq import ImtqMixin
+from .mission import MissionMixin
+from .obc_mixin import OBCMixin
+from .obc_time import TimeMixin
 
 
 class OBC(OBCMixin,
@@ -41,12 +39,15 @@ class OBC(OBCMixin,
         return self._terminal.command(cmdline)
 
     def wait_to_start(self):
-        response = self._terminal.command("getState")
-        while response != "1":
-            time.sleep(0.2)
-            response = self._terminal.command("getState")
+        self.log.debug("Waiting for OBC initialization finish")
 
-        self.log.info("OBC reported ready state")
+        start = datetime.now()
+
+        self._command("wait_for_init")
+
+        end = datetime.now()
+        duration = end - start
+        self.log.info("OBC initialization done in %s", str(duration))
 
     def reset(self):
         self._terminal.reset()

--- a/libs/drivers/burtc/Include/burtc/burtc.hpp
+++ b/libs/drivers/burtc/Include/burtc/burtc.hpp
@@ -59,7 +59,7 @@ namespace devices
 
             void ConfigureHardware();
 
-            Task<Burtc*, 2_KB, TaskPriority::P6> _task;
+            Task<Burtc*, 4_KB, TaskPriority::P6> _task;
 
             /** @brief Calculates current time interval based on selected oscillator frequency, prescaler and compare value **/
             static std::chrono::milliseconds CalculateCurrentTimeInterval();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     commands/rtc.cpp
     commands/fram.cpp
     commands/external_flash.cpp
+    commands/obc_state.cpp
     obc.h
     obc.cpp
     fault_handlers.cpp

--- a/src/commands/comm.cpp
+++ b/src/commands/comm.cpp
@@ -220,10 +220,3 @@ void CommSetIdleState(std::uint16_t argc, char* argv[])
 
     Main.Communication.CommDriver.SetTransmitterStateWhenIdle(enable ? IdleState::On : IdleState::Off);
 }
-
-void OBCGetState(uint16_t argc, char* argv[])
-{
-    UNREFERENCED_PARAMETER(argc);
-    UNREFERENCED_PARAMETER(argv);
-    Main.terminal.Printf("%d\n", atomic_load(&Main.initialized) ? 1 : 0);
-}

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -16,7 +16,7 @@ void CommReset(std::uint16_t argc, char* argv[]);
 void CommGetTelemetry(std::uint16_t argc, char* argv[]);
 void CommSetBaudRate(std::uint16_t argc, char* argv[]);
 void CommSetIdleState(std::uint16_t argc, char* argv[]);
-void OBCGetState(std::uint16_t argc, char* argv[]);
+void WaitForOBCInitialization(std::uint16_t argc, char* argv[]);
 void FSListFiles(std::uint16_t argc, char* argv[]);
 void FSWriteFile(std::uint16_t argc, char* argv[]);
 void FSReadFile(std::uint16_t argc, char* argv[]);

--- a/src/commands/obc_state.cpp
+++ b/src/commands/obc_state.cpp
@@ -1,0 +1,8 @@
+#include "commands.h"
+#include "obc.h"
+
+void WaitForOBCInitialization(std::uint16_t /*argc*/, char* /*argv*/ [])
+{
+    Main.StateFlags.WaitAny(OBC::InitializationFinishedFlag, false, InfiniteTimeout);
+    Main.terminal.Puts("Initialized");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,7 @@ static void ObcInitTask(void* param)
     obc->Hardware.Burtc.Start();
 
     LOG(LOG_LEVEL_INFO, "Intialized");
-    Main.initialized = true;
+    Main.StateFlags.Set(OBC::InitializationFinishedFlag);
 
     System::SuspendTask(NULL);
 }

--- a/src/obc.cpp
+++ b/src/obc.cpp
@@ -8,7 +8,7 @@ OBC::OBC()
       Storage(Hardware.SPI, fs, Hardware.Pins),                            //
       Imtq(Hardware.I2C.Buses.Bus),                                        //
       Experiments(fs, this->adcs.GetAdcsController(), this->timeProvider), //
-      Communication(this->Fdir, Hardware.I2C.Buses.Bus, fs, Experiments),              //
+      Communication(this->Fdir, Hardware.I2C.Buses.Bus, fs, Experiments),  //
       terminal(this->IO),                                                  //
       rtc(Hardware.I2C.Buses.Payload)
 {
@@ -16,6 +16,8 @@ OBC::OBC()
 
 void OBC::Initialize()
 {
+    this->StateFlags.Initialize();
+
     this->Fdir.Initalize();
     this->Hardware.Initialize();
 

--- a/src/obc.h
+++ b/src/obc.h
@@ -43,6 +43,8 @@
 struct OBC
 {
   public:
+    static constexpr OSEventBits InitializationFinishedFlag = 1;
+
     /** @brief Constructs @ref OBC object  */
     OBC();
 
@@ -59,7 +61,7 @@ struct OBC
     /** @brief Handle to OBC initialization task. */
     OSTaskHandle initTask;
     /** @brief Flag indicating that OBC software has finished initialization process. */
-    std::atomic<bool> initialized;
+    EventGroup StateFlags;
 
     /** @brief Persistent timer that measures mission time. */
     services::time::TimeProvider timeProvider;

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -14,7 +14,7 @@ static const TerminalCommandDescription commands[] = {
     {"receiveFrame", ReceiveFrameHandler},
     {"pauseComm", CommandPauseComm},
     {"comm_reset", CommReset},
-    {"getState", OBCGetState},
+    {"wait_for_init", WaitForOBCInitialization},
     {"listFiles", FSListFiles},
     {"writeFile", FSWriteFile},
     {"readFile", FSReadFile},


### PR DESCRIPTION
Changed busy wait for OBC initialization finish from Python tests into RTOS wait on the OBC side. Not very much but cuts about a minute from build time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/124)
<!-- Reviewable:end -->
