### PR TITLE
You've been calculating your stack size WRONG whole time - click here to see why!

### DIFF
--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -206,7 +206,7 @@ class System final : public PureStatic
      *
      * @param[in] entryPoint Pointer to task procedure.
      * @param[in] taskName Name of the new task.
-     * @param[in] stackSize Size of the new task's stack in words.
+     * @param[in] stackSize Size of the new task's stack in bytes.
      * @param[in] taskParameter Pointer to caller supplied object task context.
      * @param[in] priority New task priority.
      * @param[out] taskHandle Pointer to variable that will be filled with the created task handle.
@@ -462,7 +462,11 @@ class System final : public PureStatic
 };
 
 /**
- * RTOS Task wrapper
+ * @brief RTOS Task wrapper
+ * @tparam Param Type of parameter passed to task procedure
+ * @tparam StackSize Size of stack in bytes
+ * @tparam Priority Priority assigned to task
+ *
  */
 template <typename Param, std::uint16_t StackSize, TaskPriority Priority> class Task final
 {
@@ -514,7 +518,7 @@ Task<Param, StackSize, Priority>::Task(const char* name, Param param, HandlerTyp
 
 template <typename Param, std::uint16_t StackSize, TaskPriority Priority> OSResult Task<Param, StackSize, Priority>::Create()
 {
-    return System::CreateTask(EntryPoint, this->_taskName, StackSize / 2, static_cast<void*>(this), Priority, &this->_handle);
+    return System::CreateTask(EntryPoint, this->_taskName, StackSize, static_cast<void*>(this), Priority, &this->_handle);
 }
 
 template <typename Param, std::uint16_t StackSize, TaskPriority Priority> void Task<Param, StackSize, Priority>::EntryPoint(void* param)

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -97,7 +97,7 @@ bool CommObject::Restart()
         }
 
         const OSResult result =
-            System::CreateTask(CommObject::CommTask, "COMM Task", 1_KB, this, TaskPriority::P4, &this->_pollingTaskHandle);
+            System::CreateTask(CommObject::CommTask, "COMM Task", 2_KB, this, TaskPriority::P4, &this->_pollingTaskHandle);
         if (OS_RESULT_FAILED(result))
         {
             LOGF(LOG_LEVEL_ERROR, "[comm] Unable to create background task. Status: 0x%08x.", num(result));

--- a/libs/free_rtos_wrapper/os.cpp
+++ b/libs/free_rtos_wrapper/os.cpp
@@ -32,7 +32,9 @@ OSResult System::CreateTask(OSTaskProcedure entryPoint, //
     OSTaskHandle* taskHandle                            //
     )
 {
-    const BaseType_t result = xTaskCreate(entryPoint, taskName, stackSize, taskParameter, static_cast<uint8_t>(priority), taskHandle);
+    const auto rtosStackSize = stackSize / sizeof(StackType_t);
+
+    const BaseType_t result = xTaskCreate(entryPoint, taskName, rtosStackSize, taskParameter, static_cast<uint8_t>(priority), taskHandle);
     if (result != pdPASS)
     {
         return OSResult::NotEnoughMemory;

--- a/libs/mission/Include/mission/main.hpp
+++ b/libs/mission/Include/mission/main.hpp
@@ -309,7 +309,7 @@ namespace mission
         }
 
         if (OS_RESULT_FAILED(
-                System::CreateTask(MissionLoopControlTask, "MissionLoopControl", 2048, this, TaskPriority::P2, &this->taskHandle)))
+                System::CreateTask(MissionLoopControlTask, "MissionLoopControl", 4_KB, this, TaskPriority::P2, &this->taskHandle)))
         {
             LOG(LOG_LEVEL_ERROR, "Unable to initialize mission state. Reason: unable to create task. ");
             return false;

--- a/libs/terminal/include/terminal/terminal.h
+++ b/libs/terminal/include/terminal/terminal.h
@@ -110,7 +110,7 @@ class Terminal
     /**
      * @brief RTOS task with main loop
      */
-    Task<Terminal*, 2_KB, TaskPriority::P4> _task;
+    Task<Terminal*, 4_KB, TaskPriority::P4> _task;
 
     /**
      * @brief Command list

--- a/src/commands/rtos_status.cpp
+++ b/src/commands/rtos_status.cpp
@@ -29,6 +29,7 @@ void TaskListCommand(uint16_t argc, char* argv[])
     {
         auto& t = tasks[i];
 
-        Main.terminal.Printf("%-6c\t%-10s\t%8d\n", TaskStatuses[t.eCurrentState], t.pcTaskName, t.usStackHighWaterMark);
+        Main.terminal.Printf(
+            "%-6c\t%-10s\t%8d\n", TaskStatuses[t.eCurrentState], t.pcTaskName, t.usStackHighWaterMark * sizeof(StackType_t));
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,19 +81,6 @@ static void BlinkLed0(void* param)
     }
 }
 
-static void SmartWaitTask(void* param)
-{
-    UNREFERENCED_PARAMETER(param);
-
-    LOG(LOG_LEVEL_DEBUG, "Wait start");
-
-    while (1)
-    {
-        Main.timeProvider.LongDelay(10min);
-        LOG(LOG_LEVEL_DEBUG, "After wait");
-    }
-}
-
 static void InitSwoEndpoint(void)
 {
     void* swoEndpointHandle = SwoEndpointInit();
@@ -159,8 +146,6 @@ static void ObcInitTask(void* param)
 
     obc->Hardware.Burtc.Start();
 
-    System::CreateTask(SmartWaitTask, "SmartWait", 512, NULL, TaskPriority::P1, NULL);
-
     LOG(LOG_LEVEL_INFO, "Intialized");
     Main.initialized = true;
 
@@ -213,7 +198,7 @@ int main(void)
     Main.Hardware.Pins.Led1.High();
 
     System::CreateTask(BlinkLed0, "Blink0", 512, NULL, TaskPriority::P1, NULL);
-    System::CreateTask(ObcInitTask, "Init", 2_KB, &Main, TaskPriority::Highest, &Main.initTask);
+    System::CreateTask(ObcInitTask, "Init", 4_KB, &Main, TaskPriority::Highest, &Main.initTask);
 
     System::RunScheduler();
 


### PR DESCRIPTION
`xTaskCreate` expects parameter with size of the stack for new task in **words**. However size of the **word** is port-dependent and in case of Cortex-M3 its 4 bytes not 2 as we assumed at the begining. 

This change hides calculation of size in words by doing the division just before calling `xTaskCreate` and using size of `StackType_t`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/125)
<!-- Reviewable:end -->
