### PR TITLE
Drop the const qualifier from the state parameter of Action Descriptor action procedure.

### DIFF
--- a/libs/mission/Include/mission/base.hpp
+++ b/libs/mission/Include/mission/base.hpp
@@ -246,7 +246,7 @@ namespace mission
      * @param[in] param Pointer to action specific context.
      * @tparam State Type of the state this action operates on.
      */
-    template <typename State> using ActionProc = void (*)(const State& state, void* param);
+    template <typename State> using ActionProc = void (*)(State& state, void* param);
 
     /**
      * @brief Type of the procedure that verifies whether or not action should be performed in current state.
@@ -297,7 +297,7 @@ namespace mission
          * @brief Executes action
          * @param state System state
          */
-        inline void Execute(const State& state);
+        inline void Execute(State& state);
     };
 
     template <typename State> inline bool ActionDescriptor<State>::EvaluateCondition(const State& state)
@@ -310,7 +310,7 @@ namespace mission
         return this->condition(state, this->param);
     }
 
-    template <typename State> inline void ActionDescriptor<State>::Execute(const State& state)
+    template <typename State> inline void ActionDescriptor<State>::Execute(State& state)
     {
         if (this->actionProc != nullptr)
         {
@@ -357,7 +357,7 @@ namespace mission
          * @param state System state
          * @param param Pointer to CompositeAction object
          */
-        static void Run(const State& state, void* param);
+        static void Run(State& state, void* param);
 
         /** @brief Composite action name */
         const char* _name;
@@ -374,7 +374,7 @@ namespace mission
         return true;
     }
 
-    template <typename State, std::size_t Count> void CompositeAction<State, Count>::Run(const State& state, void* param)
+    template <typename State, std::size_t Count> void CompositeAction<State, Count>::Run(State& state, void* param)
     {
         auto This = reinterpret_cast<CompositeAction<State, Count>*>(param);
 

--- a/libs/mission/Include/mission/logic.hpp
+++ b/libs/mission/Include/mission/logic.hpp
@@ -104,9 +104,7 @@ namespace mission
      * @param[in] state System state
      * @param[in] actions List of action descriptors to run.
      */
-    template <typename State>
-    void SystemDispatchActions(const State& state, //
-        gsl::span<ActionDescriptor<State>*> actions)
+    template <typename State> void SystemDispatchActions(State& state, gsl::span<ActionDescriptor<State>*> actions)
     {
         for (auto descriptor : actions)
         {

--- a/libs/mission/adcs/Include/mission/adcs.hpp
+++ b/libs/mission/adcs/Include/mission/adcs.hpp
@@ -85,7 +85,7 @@ namespace mission
              * @param[in] param Pointer to the deployment condition private context. This pointer should point
              * at the object of AdcsPrimaryTask type.
              */
-            static void AdcsEnableBuiltinDetumbling(const SystemState& state, void* param);
+            static void AdcsEnableBuiltinDetumbling(SystemState& state, void* param);
 
             static constexpr std::uint8_t RetryCount = 3;
 

--- a/libs/mission/adcs/adcs.cpp
+++ b/libs/mission/adcs/adcs.cpp
@@ -55,7 +55,7 @@ namespace mission
             return true;
         }
 
-        void AdcsPrimaryTask::AdcsEnableBuiltinDetumbling(const SystemState& /*state*/, void* param)
+        void AdcsPrimaryTask::AdcsEnableBuiltinDetumbling(SystemState& /*state*/, void* param)
         {
             const auto context = static_cast<AdcsPrimaryTask*>(param);
             const auto result = context->coordinator.EnableBuiltinDetumbling();

--- a/libs/mission/antenna/antenna.cpp
+++ b/libs/mission/antenna/antenna.cpp
@@ -349,7 +349,7 @@ namespace mission
          * @param[in] param Pointer to the deployment condition private context. This pointer should point
          * at the object of AntennaMissionState type.
          */
-        static void AntennaDeploymentAction(const SystemState& state, void* param)
+        static void AntennaDeploymentAction(SystemState& state, void* param)
         {
             auto stateDescriptor = static_cast<AntennaMissionState*>(param);
             if (state.PersistentState.Get<state::AntennaConfiguration>().IsDeploymentDisabled())

--- a/libs/mission/beacon/BeaconUpdate.cpp
+++ b/libs/mission/beacon/BeaconUpdate.cpp
@@ -46,7 +46,7 @@ namespace mission
             ((state.Time - This->lastBeaconUpdate) >= BeaconUpdateInterval);
     }
 
-    void BeaconUpdate::Run(const SystemState& state, void* param)
+    void BeaconUpdate::Run(SystemState& state, void* param)
     {
         auto This = static_cast<BeaconUpdate*>(param);
         This->UpdateBeacon(state);
@@ -61,7 +61,7 @@ namespace mission
         {
             LOGF(LOG_LEVEL_INFO, "Beacon update rejected at %lu", time);
         }
-        else if(result.Value)
+        else if (result.Value)
         {
             this->lastBeaconUpdate = state.Time;
             LOGF(LOG_LEVEL_INFO, "Beacon set at %lu", time);

--- a/libs/mission/beacon/Include/mission/BeaconUpdate.hpp
+++ b/libs/mission/beacon/Include/mission/BeaconUpdate.hpp
@@ -56,7 +56,7 @@ namespace mission
          * @param[in] state Reference to global mission state.
          * @param[in] param Current execution context.
          */
-        static void Run(const SystemState& state, void* param);
+        static void Run(SystemState& state, void* param);
 
         /**
          * @brief Updates current beacons.

--- a/libs/mission/experiments/Include/mission/experiments.hpp
+++ b/libs/mission/experiments/Include/mission/experiments.hpp
@@ -62,7 +62,7 @@ namespace mission
              * @param state System state
              * @param param Pointer to @ref MissionExperiment
              */
-            static void StartExperiment(const SystemState& state, void* param);
+            static void StartExperiment(SystemState& state, void* param);
 
             /**
              * @brief Condition for 'Kick experiment' action
@@ -77,7 +77,7 @@ namespace mission
              * @param state System state
              * @param param Pointer to @ref MissionExperiment
              */
-            static void KickExperiment(const SystemState& state, void* param);
+            static void KickExperiment(SystemState& state, void* param);
 
             /** @brief Experiment controller */
             ::experiments::ExperimentController& _experimentController;

--- a/libs/mission/experiments/experiments.cpp
+++ b/libs/mission/experiments/experiments.cpp
@@ -73,7 +73,7 @@ namespace mission
             return This->_experimentController.IsExperimentRequested();
         }
 
-        void MissionExperimentComponent::StartExperiment(const SystemState& state, void* param)
+        void MissionExperimentComponent::StartExperiment(SystemState& state, void* param)
         {
             UNREFERENCED_PARAMETER(state);
 
@@ -91,7 +91,7 @@ namespace mission
             return This->_experimentController.InProgress();
         }
 
-        void MissionExperimentComponent::KickExperiment(const SystemState& state, void* param)
+        void MissionExperimentComponent::KickExperiment(SystemState& state, void* param)
         {
             UNREFERENCED_PARAMETER(state);
 

--- a/libs/mission/sail/Include/mission/sail.hpp
+++ b/libs/mission/sail/Include/mission/sail.hpp
@@ -78,7 +78,7 @@ namespace mission
          * @param[in] state Current mission state.
          * @param[in] param Execution context.
          */
-        static void OpenSail(const SystemState& state, void* param);
+        static void OpenSail(SystemState& state, void* param);
 
         /**
          * @brief Updates global mission state.

--- a/libs/mission/sail/sail.cpp
+++ b/libs/mission/sail/sail.cpp
@@ -53,7 +53,7 @@ namespace mission
         return true;
     }
 
-    void SailTask::OpenSail(const SystemState& state, void* param)
+    void SailTask::OpenSail(SystemState& state, void* param)
     {
         auto This = static_cast<SailTask*>(param);
         UNREFERENCED_PARAMETER(state);

--- a/libs/mission/state/Include/mission/PersistentStateSave.hpp
+++ b/libs/mission/state/Include/mission/PersistentStateSave.hpp
@@ -48,7 +48,7 @@ namespace mission
          * @param[in] state Reference to global mission state, that should contain the persistent part
          * that is supposed to be saved.
          */
-        void SaveState(const SystemState& state);
+        void SaveState(SystemState& state);
 
       private:
         /**
@@ -64,7 +64,7 @@ namespace mission
          * @param[in] state Reference to global mission state.
          * @param[in] param Current execution context.
          */
-        static void SaveState(const SystemState& state, void* param);
+        static void SaveState(SystemState& state, void* param);
 
         /**
          * @brief Storage controller that should be used to write the serialized form of the

--- a/libs/mission/state/PersistentStateSave.cpp
+++ b/libs/mission/state/PersistentStateSave.cpp
@@ -32,13 +32,13 @@ namespace mission
         return state.PersistentState.IsModified();
     }
 
-    void PeristentStateSave::SaveState(const SystemState& state, void* param)
+    void PeristentStateSave::SaveState(SystemState& state, void* param)
     {
         auto This = static_cast<PeristentStateSave*>(param);
         This->SaveState(state);
     }
 
-    void PeristentStateSave::SaveState(const SystemState& state)
+    void PeristentStateSave::SaveState(SystemState& state)
     {
         obc::WritePersistentState(state.PersistentState, this->baseAddress, this->storageAccess);
     }

--- a/libs/mission/telemetry/Include/mission/telemetry.hpp
+++ b/libs/mission/telemetry/Include/mission/telemetry.hpp
@@ -81,7 +81,7 @@ namespace mission
          * Once the process is complete the telemetry container is notified that all changes are saved.
          * @param[in] state Reference to global mission state.
          */
-        void Save(const SystemState& state);
+        void Save(SystemState& state);
 
         /**
          * @brief This procedure is responsible for appending the passed data frame to the current
@@ -108,7 +108,7 @@ namespace mission
          * @param[in] state Reference to global mission state.
          * @param[in] param Current execution context.
          */
-        static void SaveProxy(const SystemState& state, void* param);
+        static void SaveProxy(SystemState& state, void* param);
 
         /**
          * @brief File system provider.

--- a/libs/mission/telemetry/telemetry.cpp
+++ b/libs/mission/telemetry/telemetry.cpp
@@ -26,13 +26,13 @@ namespace mission
         return state.telemetry.IsModified();
     }
 
-    void TelemetryTask::SaveProxy(const SystemState& state, void* param)
+    void TelemetryTask::SaveProxy(SystemState& state, void* param)
     {
         auto This = static_cast<TelemetryTask*>(param);
         This->Save(state);
     }
 
-    void TelemetryTask::Save(const SystemState& state)
+    void TelemetryTask::Save(SystemState& state)
     {
         std::array<std::uint8_t, state::ManagedTelemetry::TotalSerializedSize> buffer;
         Writer writer(buffer);

--- a/libs/mission/time/Include/mission/time.hpp
+++ b/libs/mission/time/Include/mission/time.hpp
@@ -136,13 +136,13 @@ namespace mission
          * @param[in] state Reference to global mission state.
          * @param[in] param Current execution context.
          */
-        static void CorrectTimeProxy(const SystemState& state, void* param);
+        static void CorrectTimeProxy(SystemState& state, void* param);
 
         /**
          * @brief Time correction procedure, that will correct current time based on the external RTC.
          * @param[in] state Reference to global mission state.
          */
-        void CorrectTime(const SystemState& state);
+        void CorrectTime(SystemState& state);
 
         /**
          * @brief Time provider reference.

--- a/libs/mission/time/time.cpp
+++ b/libs/mission/time/time.cpp
@@ -63,13 +63,13 @@ namespace mission
         return (state.Time - timeState.LastMissionTime()) >= TimeCorrectionPeriod;
     }
 
-    void TimeTask::CorrectTimeProxy(const SystemState& state, void* param)
+    void TimeTask::CorrectTimeProxy(SystemState& state, void* param)
     {
         TimeTask* This = static_cast<TimeTask*>(param);
         This->CorrectTime(state);
     }
 
-    void TimeTask::CorrectTime(const SystemState& state)
+    void TimeTask::CorrectTime(SystemState& state)
     {
         auto time = this->provider.GetCurrentTime();
         if (!time.HasValue)

--- a/libs/state/Include/state/struct.h
+++ b/libs/state/Include/state/struct.h
@@ -43,12 +43,12 @@ struct SystemState
     /**
      * @brief Satellite's persistent state.
      */
-    mutable state::SystemPersistentState PersistentState;
+    state::SystemPersistentState PersistentState;
 
     /**
      * @brief Container of all used telemetry elements.
      */
-    mutable state::ManagedTelemetry telemetry;
+    state::ManagedTelemetry telemetry;
 };
 
 #endif /* LIBS_STATE_INCLUDE_STATE_STRUCT_H_ */

--- a/unit_tests/base/Include/mock/ActionDescriptorMock.hpp
+++ b/unit_tests/base/Include/mock/ActionDescriptorMock.hpp
@@ -10,12 +10,12 @@
 template <typename State, typename Tag> struct ActionDescriptorMock : public mission::Action
 {
     MOCK_METHOD1_T(ConditionProc, bool(const State& state));
-    MOCK_METHOD1_T(ActionProc, void(const State& state));
+    MOCK_METHOD1_T(ActionProc, void(State& state));
     mission::ActionDescriptor<State> BuildAction();
 
     static bool ConditionEntry(const State& state, void* param);
 
-    static void ActionEntry(const State& state, void* param);
+    static void ActionEntry(State& state, void* param);
 };
 
 template <typename State, typename Tag>
@@ -27,8 +27,8 @@ bool ActionDescriptorMock<State, Tag>::ConditionEntry(const State& state, //
 }
 
 template <typename State, typename Tag>
-void ActionDescriptorMock<State, Tag>::ActionEntry(const State& state, //
-    void* param                                                        //
+void ActionDescriptorMock<State, Tag>::ActionEntry(State& state, //
+    void* param                                                  //
     )
 {
     static_cast<ActionDescriptorMock<State, Tag>*>(param)->ActionProc(state);


### PR DESCRIPTION
Recent additions to obc's state showed that there are cases when actions also
have to change (although in a very limited way) obc state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/145)
<!-- Reviewable:end -->
