### PR TITLE
Use FlightModel platform on CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 def build() {
-	bat "cmake -DJLINK_SN=${env.EFM_JLINK} -DMOCK_COM=${env.MOCK_COM} -DOBC_COM=${env.OBC_COM} -DGPIO_COM=${env.GPIO_COM} -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=1 -DUSE_EXTERNAL_FLASH=1 -G \"MinGW Makefiles\" ../source"
-	bat "make pwsat"
-	step([$class: 'ArtifactArchiver', artifacts: 'build/DevBoard/**/*', fingerprint: true])
+	bat "cmake -DJLINK_SN=${env.EFM_JLINK_FM} -DMOCK_COM=${env.MOCK_COM_FM} -DOBC_COM=${env.OBC_COM_FM} -DGPIO_COM=${env.GPIO_COM_FM} -DTARGET_PLATFORM=FlightModel -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=1 -G \"MinGW Makefiles\" ../source"
+	bat "make pwsat boot fm_terminal"
+	step([$class: 'ArtifactArchiver', artifacts: 'build/FlightModel/**/*', fingerprint: true])
 }
 
 def unitTests() {
 	bat "make unit_tests"
 	bat "make unit_tests.run -j1"
-	step([$class: 'JUnitResultArchiver', testResults: 'build/DevBoard/unit_tests_*.xml'])
+	step([$class: 'JUnitResultArchiver', testResults: 'build/FlightModel/unit_tests_*.xml'])
 }
 
 def reports() {
@@ -17,7 +17,7 @@ def reports() {
 		allowMissing: false,
 		alwaysLinkToLastBuild: false,
 		keepAll: false,
-		reportDir: 'build/DevBoard/reports/memory',
+		reportDir: 'build/FlightModel/reports/memory',
 		reportFiles: 'index.html',
 		reportName: 'Memory usage'
   ])
@@ -25,8 +25,9 @@ def reports() {
 
 def integrationTests() {
 	lock('hardware') {
+		bat "make boot.flash"
 		bat "make integration_tests"
-		step([$class: 'JUnitResultArchiver', testResults: 'build/DevBoard/integration-tests.xml'])
+		step([$class: 'JUnitResultArchiver', testResults: 'build/FlightModel/integration-tests.xml'])
 	}
 }
 
@@ -49,7 +50,7 @@ def coverage() {
 		allowMissing: false,
 		alwaysLinkToLastBuild: false,
 		keepAll: false,
-		reportDir: 'build/DevBoard/reports/coverage',
+		reportDir: 'build/FlightModel/reports/coverage',
 		reportFiles: 'index.html',
 		reportName: 'Code Coverage'
     ])

--- a/boot/comms.cpp
+++ b/boot/comms.cpp
@@ -52,9 +52,9 @@ static std::array<Command, 12> Commands = {
 
 #define UPLOADBLOCKSIZE 256
 
-static uint8_t msgId;
+static volatile uint8_t msgId;
 
-uint8_t uartReceived;
+volatile uint8_t uartReceived;
 
 void COMMS_Init(void)
 {

--- a/boot/comms.h
+++ b/boot/comms.h
@@ -18,6 +18,6 @@
 void COMMS_Init(void);
 void COMMS_processMsg(void);
 
-extern uint8_t uartReceived;
+extern volatile uint8_t uartReceived;
 
 #endif

--- a/integration_tests/tests/test_telecommands_comm.py
+++ b/integration_tests/tests/test_telecommands_comm.py
@@ -61,4 +61,4 @@ class CommTelecommandsTest(BaseTest):
         self.assertEqual(frame.seq(), 0)
         self.assertEqual(frame.payload(), [0x11, 0])
 
-        self.assertTrue(event.wait_for_change(10))
+        self.assertTrue(event.wait_for_change(30))

--- a/src/commands/dma.cpp
+++ b/src/commands/dma.cpp
@@ -13,10 +13,10 @@ void DMAInfo(std::uint16_t argc, char* argv[])
     for (auto i = 0; i < DMA_CHAN_COUNT; i++)
     {
         auto enabled = DMA_ChannelEnabled(i);
-        bool active;
+        bool active = false;
         DMADRV_TransferActive(i, &active);
 
-        int rem;
+        int rem = 0;
         DMADRV_TransferRemainingCount(i, &rem);
 
         Main.terminal.Printf("%d\t%c\t%d\n", i, enabled ? 'E' : 'D', rem);

--- a/test/fm_terminal/CMakeLists.txt
+++ b/test/fm_terminal/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCES
 
 add_executable(${NAME} EXCLUDE_FROM_ALL ${SOURCES})
 
-set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-T ${UPPER_LINKER_SCRIPT} -Wl,-Map=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${NAME}.map -specs=nano.specs -specs=nosys.specs")
+set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-T ${UPPER_LINKER_SCRIPT} -L ${PLATFORM_PATH} -Wl,-Map=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${NAME}.map -specs=nano.specs -specs=nosys.specs")
 
 target_link_libraries(${NAME}
     assert

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -2,14 +2,12 @@ include(common.cmake)
 set(UNIT_TEST_EXECUTABLES "" CACHE INTERNAL "unit tests list" FORCE)
 
 add_subdirectory(base)
-add_subdirectory(empty)
-add_subdirectory(drivers)
-add_subdirectory(communication)
-add_subdirectory(mission)
-add_subdirectory(state)
 
 add_subdirectory(properties)
-
+add_subdirectory(mission)
+add_subdirectory(drivers)
+add_subdirectory(communication)
+add_subdirectory(state)
 add_subdirectory(others)
 
 message(STATUS "Unit tests=${UNIT_TEST_EXECUTABLES}")


### PR DESCRIPTION
EM is now connected to CI machine. This pull requests changes CI builds to use FlightModel platform instead of DevBoard.

Older branches (with DevBoard CI build) will still work - both environments are available

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/148)
<!-- Reviewable:end -->
