### PR TITLE
Telemetry acquisition

### DIFF
--- a/doc/groups.h
+++ b/doc/groups.h
@@ -70,6 +70,5 @@
  
  /**
  * @defgroup telemetry Telemetry
- * @ingroup StateDef
  * @brief This module is responsible for telemetry management.
  */

--- a/doc/telemetry_acquisition.md
+++ b/doc/telemetry_acquisition.md
@@ -1,0 +1,3 @@
+# Telemetry Acquisition {#telemetry_acquisition_list}
+
+List below shows all available tasks that are resposnible for acquiring live telemetry, please refer to specific documentation pages for details.

--- a/doxyfile
+++ b/doxyfile
@@ -228,7 +228,11 @@ TAB_SIZE = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES += "telecommand=\xrefitem tc_list \"\" \"\"" "mission_task=\xrefitem mission_task_list \"\" \"\"" "telemetry_element=\xrefitem telemetry_element_list \"\" \"\"" "persistent_state=\xrefitem persistent_state_list \"\" \"\""
+ALIASES += "telecommand=\xrefitem tc_list \"\" \"\"" \
+    "mission_task=\xrefitem mission_task_list \"\" \"\"" \
+    "telemetry_element=\xrefitem telemetry_element_list \"\" \"\"" \
+    "persistent_state=\xrefitem persistent_state_list \"\" \"\"" \
+    "telemetry_acquisition=\xrefitem telemetry_acquisition_list \"\" \"\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -20,4 +20,4 @@ add_subdirectory(settings)
 add_subdirectory(experiments)
 add_subdirectory(error_counter)
 add_subdirectory(boot_params)
-
+add_subdirectory(telemetry)

--- a/libs/drivers/comm/CMakeLists.txt
+++ b/libs/drivers/comm/CMakeLists.txt
@@ -3,6 +3,7 @@ set(NAME comm)
 set(SOURCES
     comm.cpp
     Frame.cpp
+    CommTelemetry.cpp
     Include/comm/Beacon.hpp
     Include/comm/comm.hpp
     Include/comm/CommDriver.hpp

--- a/libs/drivers/comm/CommTelemetry.cpp
+++ b/libs/drivers/comm/CommTelemetry.cpp
@@ -70,19 +70,19 @@ void CommTelemetry::Write(Writer& writer) const
 
 bool CommTelemetry::IsDifferent(const CommTelemetry& arg) const
 {
-    return this->transmitterCurrentConsumption != arg.transmitterCurrentConsumption &&    //
-        this->receiverCurrentConsumption != this->receiverCurrentConsumption &&           //
-        this->dopplerOffset != this->dopplerOffset &&                                     //
-        this->vcc != this->vcc &&                                                         //
-        this->oscilatorTemperature != this->oscilatorTemperature &&                       //
-        this->receiverAmplifierTemperature != this->receiverAmplifierTemperature &&       //
-        this->signalStrength != this->signalStrength &&                                   //
-        this->rFReflectedPower != this->rFReflectedPower &&                               //
-        this->transmitterAmplifierTemperature != this->transmitterAmplifierTemperature && //
-        this->rFForwardPower != this->rFForwardPower &&                                   //
-        this->transmitterState.BeaconState != this->transmitterState.BeaconState &&       //
-        this->transmitterState.StateWhenIdle != this->transmitterState.StateWhenIdle &&   //
-        this->transmitterState.TransmitterBitRate != this->transmitterState.TransmitterBitRate;
+    return this->transmitterCurrentConsumption != arg.transmitterCurrentConsumption ||  //
+        this->receiverCurrentConsumption != arg.receiverCurrentConsumption ||           //
+        this->dopplerOffset != arg.dopplerOffset ||                                     //
+        this->vcc != arg.vcc ||                                                         //
+        this->oscilatorTemperature != arg.oscilatorTemperature ||                       //
+        this->receiverAmplifierTemperature != arg.receiverAmplifierTemperature ||       //
+        this->signalStrength != arg.signalStrength ||                                   //
+        this->rFReflectedPower != arg.rFReflectedPower ||                               //
+        this->transmitterAmplifierTemperature != arg.transmitterAmplifierTemperature || //
+        this->rFForwardPower != arg.rFForwardPower ||                                   //
+        this->transmitterState.BeaconState != arg.transmitterState.BeaconState ||       //
+        this->transmitterState.StateWhenIdle != arg.transmitterState.StateWhenIdle ||   //
+        this->transmitterState.TransmitterBitRate != arg.transmitterState.TransmitterBitRate;
 }
 
 COMM_END

--- a/libs/drivers/comm/CommTelemetry.cpp
+++ b/libs/drivers/comm/CommTelemetry.cpp
@@ -1,0 +1,88 @@
+#include "CommTelemetry.hpp"
+#include "base/Reader.h"
+#include "base/Writer.h"
+
+COMM_BEGIN
+
+CommTelemetry::CommTelemetry()
+    : transmitterCurrentConsumption(0),   //
+      receiverCurrentConsumption(0),      //
+      dopplerOffset(0),                   //
+      vcc(0),                             //
+      oscilatorTemperature(0),            //
+      receiverAmplifierTemperature(0),    //
+      signalStrength(0),                  //
+      rFReflectedPower(0),                //
+      transmitterAmplifierTemperature(0), //
+      rFForwardPower(0),                  //
+      transmitterState{}
+{
+}
+
+CommTelemetry::CommTelemetry(const ReceiverTelemetry& receiver, const TransmitterTelemetry& transmitter, const TransmitterState& state)
+    : transmitterCurrentConsumption(transmitter.TransmitterCurrentConsumption), //
+      receiverCurrentConsumption(receiver.ReceiverCurrentConsumption),          //
+      dopplerOffset(receiver.DopplerOffset),                                    //
+      vcc(receiver.Vcc),                                                        //
+      oscilatorTemperature(receiver.OscilatorTemperature),                      //
+      receiverAmplifierTemperature(receiver.AmplifierTemperature),              //
+      signalStrength(receiver.SignalStrength),                                  //
+      rFReflectedPower(transmitter.RFReflectedPower),                           //
+      transmitterAmplifierTemperature(transmitter.AmplifierTemperature),        //
+      rFForwardPower(transmitter.RFForwardPower),                               //
+      transmitterState(state)
+{
+}
+
+void CommTelemetry::Read(Reader& reader)
+{
+    this->transmitterCurrentConsumption = reader.ReadWordLE();
+    this->receiverCurrentConsumption = reader.ReadWordLE();
+    this->dopplerOffset = reader.ReadWordLE();
+    this->vcc = reader.ReadWordLE();
+    this->oscilatorTemperature = reader.ReadWordLE();
+    this->receiverAmplifierTemperature = reader.ReadWordLE();
+    this->signalStrength = reader.ReadWordLE();
+    this->rFReflectedPower = reader.ReadWordLE();
+    this->transmitterAmplifierTemperature = reader.ReadWordLE();
+    this->rFForwardPower = reader.ReadWordLE();
+    this->transmitterState.BeaconState = (reader.ReadByte() != 0);
+    this->transmitterState.StateWhenIdle = static_cast<IdleState>(reader.ReadByte());
+    this->transmitterState.TransmitterBitRate = static_cast<Bitrate>(reader.ReadByte());
+}
+
+void CommTelemetry::Write(Writer& writer) const
+{
+    writer.WriteWordLE(this->transmitterCurrentConsumption);
+    writer.WriteWordLE(this->receiverCurrentConsumption);
+    writer.WriteWordLE(this->dopplerOffset);
+    writer.WriteWordLE(this->vcc);
+    writer.WriteWordLE(this->oscilatorTemperature);
+    writer.WriteWordLE(this->receiverAmplifierTemperature);
+    writer.WriteWordLE(this->signalStrength);
+    writer.WriteWordLE(this->rFReflectedPower);
+    writer.WriteWordLE(this->transmitterAmplifierTemperature);
+    writer.WriteWordLE(this->rFForwardPower);
+    writer.WriteByte(this->transmitterState.BeaconState);
+    writer.WriteByte(num(this->transmitterState.StateWhenIdle));
+    writer.WriteByte(num(this->transmitterState.TransmitterBitRate));
+}
+
+bool CommTelemetry::IsDifferent(const CommTelemetry& arg) const
+{
+    return this->transmitterCurrentConsumption != arg.transmitterCurrentConsumption &&    //
+        this->receiverCurrentConsumption != this->receiverCurrentConsumption &&           //
+        this->dopplerOffset != this->dopplerOffset &&                                     //
+        this->vcc != this->vcc &&                                                         //
+        this->oscilatorTemperature != this->oscilatorTemperature &&                       //
+        this->receiverAmplifierTemperature != this->receiverAmplifierTemperature &&       //
+        this->signalStrength != this->signalStrength &&                                   //
+        this->rFReflectedPower != this->rFReflectedPower &&                               //
+        this->transmitterAmplifierTemperature != this->transmitterAmplifierTemperature && //
+        this->rFForwardPower != this->rFForwardPower &&                                   //
+        this->transmitterState.BeaconState != this->transmitterState.BeaconState &&       //
+        this->transmitterState.StateWhenIdle != this->transmitterState.StateWhenIdle &&   //
+        this->transmitterState.TransmitterBitRate != this->transmitterState.TransmitterBitRate;
+}
+
+COMM_END

--- a/libs/drivers/comm/Include/comm/CommDriver.hpp
+++ b/libs/drivers/comm/Include/comm/CommDriver.hpp
@@ -19,7 +19,10 @@ COMM_BEGIN
  * @remark Do not access directly the fields of this type, instead use the comm driver interface to
  * perform requested action.
  */
-class CommObject final : public ITransmitter, public IBeaconController
+
+class CommObject final : public ITransmitter,      //
+                         public IBeaconController, //
+                         public ICommTelemetryProvider
 {
   public:
     /**
@@ -211,6 +214,8 @@ class CommObject final : public ITransmitter, public IBeaconController
      * Additionally it resets hardware watchdog either via transmitter or via receiver.
      */
     void PollHardware();
+
+    virtual bool GetTelemetry(CommTelemetry& telemetry) final override;
 
     /** @brief Error counter type */
     using ErrorCounter = error_counter::ErrorCounter<1>;

--- a/libs/drivers/comm/Include/comm/CommTelemetry.hpp
+++ b/libs/drivers/comm/Include/comm/CommTelemetry.hpp
@@ -1,0 +1,106 @@
+#ifndef LIBS_DRIVERS_COMM_TELEMETRY_HPP
+#define LIBS_DRIVERS_COMM_TELEMETRY_HPP
+
+#pragma once
+
+#include <cstdint>
+#include "comm.hpp"
+
+COMM_BEGIN
+
+/**
+ * @brief This class represents complete communication module telemetry object as it is presented and exposed
+ * to the rest of the system.
+ */
+class CommTelemetry
+{
+  public:
+    /**
+     * @brief TimeState telemetry unique identifier.
+     */
+    static constexpr int Id = 2;
+
+    /**
+     * @brief ctor.
+     */
+    CommTelemetry();
+
+    /**
+     * @brief ctor.
+     * @param[in] receiver Current receiver telemetry
+     * @param[in] transmitter Current transmitter telemetry
+     * @param[in] state Current transmitter configuration
+     */
+    CommTelemetry(const ReceiverTelemetry& receiver, const TransmitterTelemetry& transmitter, const TransmitterState& state);
+
+    /**
+     * @brief Read the comm telemetry from passed reader.
+     * @param[in] reader Buffer reader that should be used to read the serialized state.
+     */
+    void Read(Reader& reader);
+
+    /**
+     * @brief Write the comm telemetry to passed buffer writer object.
+     * @param[in] writer Buffer writer object that should be used to write the serialized state
+     * of the time subsystem state.
+     */
+    void Write(Writer& writer) const;
+
+    /**
+     * @brief Returns size of the serialized state in bytes.
+     * @return Size of the serialized state in bytes.
+     */
+    static constexpr std::uint32_t Size();
+
+    /**
+     * @brief Procedure that verifies whether two CommTelemetry objects differ enough to so they should be
+     * treated as two distinct states.
+     * @param[in] arg Object to compare to.
+     *
+     * @remark This version is based on value equality.
+     * @return True in case objects are different, false otherwise.
+     */
+    bool IsDifferent(const CommTelemetry& arg) const;
+
+  private:
+    /** @brief Raw measurement value of the transmitter current consumption. */
+    std::uint16_t transmitterCurrentConsumption;
+
+    /** @brief Raw measurement value of the receiver current consumption. */
+    std::uint16_t receiverCurrentConsumption;
+
+    /** @brief Raw measurement value of the instantaneous Doppler offset of the signal at the receiver port. */
+    std::uint16_t dopplerOffset;
+
+    /** @brief Raw measurement value of the power bus voltage.*/
+    std::uint16_t vcc;
+
+    /** @brief Raw measurement value of the local oscillator temperature. */
+    std::uint16_t oscilatorTemperature;
+
+    /** @brief Raw measurement value of the power amplifier temperature. */
+    std::uint16_t receiverAmplifierTemperature;
+
+    /** @brief Raw measurement value of the instantaneous signal strength of the signal at the receiver. */
+    std::uint16_t signalStrength;
+
+    /** @brief Raw measurement value of the instantaneous RF reflected power at the transmitter port. */
+    std::uint16_t rFReflectedPower;
+
+    /** @brief Raw measurement value of the power amplifier temperature. */
+    std::uint16_t transmitterAmplifierTemperature;
+
+    /** @brief Raw measurement value of the instantaneous RF forward power at the transmitter port. */
+    std::uint16_t rFForwardPower;
+
+    TransmitterState transmitterState;
+};
+
+constexpr std::uint32_t CommTelemetry::Size()
+{
+    return 10 * sizeof(std::uint16_t) + 3 * sizeof(std::uint8_t);
+}
+
+COMM_END
+
+#endif

--- a/libs/drivers/comm/Include/comm/comm.hpp
+++ b/libs/drivers/comm/Include/comm/comm.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <gsl/span>
+#include "base/fwd.hpp"
 
 #define COMM_BEGIN                                                                                                                         \
     namespace devices                                                                                                                      \
@@ -48,10 +49,12 @@ COMM_BEGIN
 
 class Frame;
 class Beacon;
+class CommTelemetry;
 
 struct IHandleFrame;
 struct ITransmitter;
 struct IBeaconController;
+struct ICommTelemetryProvider;
 
 /**
  * @brief Maximum allowed single frame content length.
@@ -210,6 +213,10 @@ enum class Address
     Transmitter = 0x61,
 };
 
+struct ICommTelemetryProvider
+{
+    virtual bool GetTelemetry(CommTelemetry& telemetry) = 0;
+};
 /** @}*/
 COMM_END
 

--- a/libs/drivers/comm/Include/comm/comm.hpp
+++ b/libs/drivers/comm/Include/comm/comm.hpp
@@ -213,8 +213,16 @@ enum class Address
     Transmitter = 0x61,
 };
 
+/**
+ * @brief Interface of object capable providing complete comm telemetry.
+ */
 struct ICommTelemetryProvider
 {
+    /**
+     * @brief Acquires complete current comm hardware telemetry.
+     * @param[out] telemetry Object that should be filled with updated telemetry.
+     * @return Operation status. True on success, false otherwise.
+     */
     virtual bool GetTelemetry(CommTelemetry& telemetry) = 0;
 };
 /** @}*/

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -200,7 +200,7 @@ bool CommObject::RemoveFrame()
 
 bool CommObject::GetReceiverTelemetry(ReceiverTelemetry& telemetry)
 {
-    uint8_t buffer[sizeof(ReceiverTelemetry)];
+    uint8_t buffer[sizeof(ReceiverTelemetry)] = {0};
     const bool status = this->SendCommandWithResponse(Address::Receiver, num(ReceiverCommand::GetTelemetry), span<uint8_t>(buffer));
     if (!status)
     {
@@ -233,7 +233,7 @@ bool CommObject::GetReceiverTelemetry(ReceiverTelemetry& telemetry)
 
 bool CommObject::GetTransmitterTelemetry(TransmitterTelemetry& telemetry)
 {
-    uint8_t buffer[sizeof(TransmitterTelemetry)];
+    uint8_t buffer[sizeof(TransmitterTelemetry)] = {0};
     const bool status = this->SendCommandWithResponse(Address::Transmitter, num(TransmitterCommand::GetTelemetry), span<uint8_t>(buffer));
     if (!status)
     {
@@ -406,7 +406,7 @@ bool CommObject::SetTransmitterBitRate(Bitrate bitrate)
 
 bool CommObject::GetTransmitterState(TransmitterState& state)
 {
-    std::uint8_t response;
+    std::uint8_t response = 0;
     const bool status = SendCommandWithResponse(Address::Transmitter, //
         num(TransmitterCommand::GetState),                            //
         gsl::span<std::uint8_t>(&response, 1)                         //

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include "Beacon.hpp"
 #include "CommDriver.hpp"
+#include "CommTelemetry.hpp"
 #include "Frame.hpp"
 #include "IHandleFrame.hpp"
 #include "base/os.h"
@@ -428,6 +429,33 @@ bool CommObject::GetTransmitterState(TransmitterState& state)
     };
 
     state.TransmitterBitRate = conversionArray[(response & 0x0c) >> 2];
+    return true;
+}
+
+bool CommObject::GetTelemetry(CommTelemetry& telemetry)
+{
+    TransmitterTelemetry transmitter;
+    ReceiverTelemetry receiver;
+    TransmitterState state;
+    if (!GetTransmitterTelemetry(transmitter))
+    {
+        LOG(LOG_LEVEL_ERROR, "[comm] Unable to acquire transmitter telemetry. ");
+        return false;
+    }
+
+    if (!GetReceiverTelemetry(receiver))
+    {
+        LOG(LOG_LEVEL_ERROR, "[comm] Unable to acquire receiver telemetry. ");
+        return false;
+    }
+
+    if (!GetTransmitterState(state))
+    {
+        LOG(LOG_LEVEL_ERROR, "[comm] Unable to acquire transmitter state. ");
+        return false;
+    }
+
+    telemetry = CommTelemetry(receiver, transmitter, state);
     return true;
 }
 

--- a/libs/drivers/gyro/Include/gyro/gyro.h
+++ b/libs/drivers/gyro/Include/gyro/gyro.h
@@ -11,7 +11,7 @@
  *
  * This driver is responsible for
  *  - direct communication with the hardware,
- *  - initialisation and data readout
+ *  - initialization and data readout
  *
  *  @{
  */
@@ -32,7 +32,7 @@ namespace devices
         constexpr std::chrono::milliseconds ConfigDelay{100};
 
         /**
-         * @brief Data readed from gyroscope.
+         * @brief Data read from gyroscope.
          */
         struct GyroRawData
         {
@@ -57,13 +57,13 @@ namespace devices
             }
 
             /**
-             * @brief Responsible for initialising gyroscope.
+             * @brief Responsible for initializing gyroscope.
              * @return Operation status.
              * Re-sets all internal registers to known and proper state.
              * After finish gyroscope will be in free-running mode and data will be available for reading.
              *
              * Settings applied:
-             * 	 - Sample rate divider of 1,
+             *   - Sample rate divider of 1,
              *   - 5 Hz cut-off Low Pass Filter,
              *   - 500 Hz sample rate,
              *   - PLL with X Gyro reference clock source

--- a/libs/mission/antenna/Include/mission/antenna_task.hpp
+++ b/libs/mission/antenna/Include/mission/antenna_task.hpp
@@ -23,7 +23,7 @@ namespace mission
          * The purpose of Action part is to coordinate the antenna deployment. This part is executed
          * only if following condition are met:
          * - The initial silent mission period is over
-         * - The antennas are not curretnly being deployed
+         * - The antennas are not currently being deployed
          */
         struct AntennaTask : public Update, public Action
         {

--- a/libs/mission/comm/Include/mission/comm.hpp
+++ b/libs/mission/comm/Include/mission/comm.hpp
@@ -19,6 +19,7 @@ namespace mission
 
     /**
      * @brief Task that is responsible for control of the communication.
+     * @mission_task
      */
     class CommTask : public Action, public IIdleStateController
     {
@@ -27,6 +28,7 @@ namespace mission
          * @brief ctor.
          *
          * To support single argument construction.
+         * @param[in] transmitter Reference to object providing frame sending capability.
          */
         CommTask(devices::comm::ITransmitter& transmitter);
 

--- a/libs/mission/comm/Include/mission/idle_state_controller.hpp
+++ b/libs/mission/comm/Include/mission/idle_state_controller.hpp
@@ -8,7 +8,7 @@ namespace mission
     /**
      * @brief Idle state controller.
      *
-     * @ingroup comm
+     * @ingroup mission
      */
     struct IIdleStateController
     {

--- a/libs/mission/telemetry/CMakeLists.txt
+++ b/libs/mission/telemetry/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(${NAME}
     mission 
     state
     fs
+    telemetry
 )
 
 target_format_sources(${NAME} "${SOURCES}")

--- a/libs/mission/telemetry/Include/mission/telemetry.hpp
+++ b/libs/mission/telemetry/Include/mission/telemetry.hpp
@@ -8,7 +8,7 @@
 #include "fs/fs.h"
 #include "gsl/span"
 #include "mission/base.hpp"
-#include "state/struct.h"
+#include "telemetry/state.hpp"
 
 namespace mission
 {
@@ -72,7 +72,7 @@ namespace mission
          * @brief Builds action descriptor for this task.
          * @return Action descriptor - the telemetry change save task.
          */
-        ActionDescriptor<SystemState> BuildAction();
+        ActionDescriptor<telemetry::TelemetryState> BuildAction();
 
         /**
          * @brief This procedure extracts modified parts of the telemetry and saves it to the telemetry
@@ -81,7 +81,7 @@ namespace mission
          * Once the process is complete the telemetry container is notified that all changes are saved.
          * @param[in] state Reference to global mission state.
          */
-        void Save(SystemState& state);
+        void Save(telemetry::TelemetryState& state);
 
         /**
          * @brief This procedure is responsible for appending the passed data frame to the current
@@ -99,7 +99,7 @@ namespace mission
          * @param[in] param Current execution context.
          * @return true if there are telemetry changes that should be saved, false otherwise.
          */
-        static bool SaveCondition(const SystemState& state, void* param);
+        static bool SaveCondition(const telemetry::TelemetryState& state, void* param);
 
         /**
          * @brief This procedure is responsible for appending the passed data frame to the current
@@ -108,7 +108,7 @@ namespace mission
          * @param[in] state Reference to global mission state.
          * @param[in] param Current execution context.
          */
-        static void SaveProxy(SystemState& state, void* param);
+        static void SaveProxy(telemetry::TelemetryState& state, void* param);
 
         /**
          * @brief File system provider.

--- a/libs/mission/telemetry/Include/mission/telemetry.hpp
+++ b/libs/mission/telemetry/Include/mission/telemetry.hpp
@@ -44,7 +44,7 @@ namespace mission
     /**
      * @brief This task is responsible for observing the telemetry container state and as soon
      * as change is observed extract save it to telemetry event file.
-     * @mission_task
+     * @telemetry_acquisition
      *
      * This task uses two files for saving the state of the telemetry changes:
      * - current telemetry file - This file is actively used and contains the most recent telemetry changes.

--- a/libs/mission/telemetry/telemetry.cpp
+++ b/libs/mission/telemetry/telemetry.cpp
@@ -1,7 +1,7 @@
 #include "mission/telemetry.hpp"
 #include <cassert>
 #include "logger/logger.h"
-#include "state/struct.h"
+#include "telemetry/state.hpp"
 
 namespace mission
 {
@@ -11,9 +11,9 @@ namespace mission
     {
     }
 
-    ActionDescriptor<SystemState> TelemetryTask::BuildAction()
+    ActionDescriptor<telemetry::TelemetryState> TelemetryTask::BuildAction()
     {
-        ActionDescriptor<SystemState> descriptor;
+        ActionDescriptor<telemetry::TelemetryState> descriptor;
         descriptor.name = "Save telemetry to file";
         descriptor.param = this;
         descriptor.condition = SaveCondition;
@@ -21,22 +21,22 @@ namespace mission
         return descriptor;
     }
 
-    bool TelemetryTask::SaveCondition(const SystemState& state, void* /*param*/)
+    bool TelemetryTask::SaveCondition(const telemetry::TelemetryState& state, void* /*param*/)
     {
         return state.telemetry.IsModified();
     }
 
-    void TelemetryTask::SaveProxy(SystemState& state, void* param)
+    void TelemetryTask::SaveProxy(telemetry::TelemetryState& state, void* param)
     {
         auto This = static_cast<TelemetryTask*>(param);
         This->Save(state);
     }
 
-    void TelemetryTask::Save(SystemState& state)
+    void TelemetryTask::Save(telemetry::TelemetryState& stateObject)
     {
-        std::array<std::uint8_t, state::ManagedTelemetry::TotalSerializedSize> buffer;
+        std::array<std::uint8_t, telemetry::ManagedTelemetry::TotalSerializedSize> buffer;
         Writer writer(buffer);
-        state.telemetry.WriteModified(writer);
+        stateObject.telemetry.WriteModified(writer);
         assert(writer.Status());
         if (!writer.Status())
         {
@@ -52,7 +52,7 @@ namespace mission
 
         if (SaveToFile(content))
         {
-            state.telemetry.CommitCapture();
+            stateObject.telemetry.CommitCapture();
         }
     }
 

--- a/libs/obc/hardware/Include/obc/hardware.h
+++ b/libs/obc/hardware/Include/obc/hardware.h
@@ -108,7 +108,7 @@ namespace obc
          */
         OBCHardware(error_counter::ErrorCounting& errorCounting, services::power::IPowerControl&, TimeAction& burtcTickHandler);
 
-        /** @brief Initializies OBC hardware */
+        /** @brief Initializes OBC hardware */
         void Initialize();
 
         /** @brief Initializies OBC hardware after FreeRTOS is initialized */

--- a/libs/state/CMakeLists.txt
+++ b/libs/state/CMakeLists.txt
@@ -7,7 +7,6 @@ set(SOURCES
     Include/state/time/TimeCorrectionConfiguration.hpp
     Include/state/struct.h
     Include/state/PersistentState.hpp
-    Include/state/Telemetry.hpp
     Include/state/fwd.hpp
     state.cpp
     Antenna.cpp

--- a/libs/state/Include/state/fwd.hpp
+++ b/libs/state/Include/state/fwd.hpp
@@ -15,10 +15,6 @@ namespace state
     template <typename StatePolicy, typename... Parts> class PersistentState;
 
     typedef PersistentState<StateTrackingPolicy, AntennaConfiguration, TimeState, TimeCorrectionConfiguration> SystemPersistentState;
-
-    template <typename... Type> class Telemetry;
-
-    typedef Telemetry<state::TimeState> ManagedTelemetry;
 }
 
 class SystemState;

--- a/libs/state/Include/state/struct.h
+++ b/libs/state/Include/state/struct.h
@@ -6,7 +6,6 @@
 #include <chrono>
 #include "PersistentState.hpp"
 #include "StatePolicies.hpp"
-#include "Telemetry.hpp"
 #include "adcs/adcs.hpp"
 #include "antenna/AntennaState.hpp"
 #include "base/os.h"
@@ -44,11 +43,6 @@ struct SystemState
      * @brief Satellite's persistent state.
      */
     state::SystemPersistentState PersistentState;
-
-    /**
-     * @brief Container of all used telemetry elements.
-     */
-    state::ManagedTelemetry telemetry;
 };
 
 #endif /* LIBS_STATE_INCLUDE_STATE_STRUCT_H_ */

--- a/libs/state/Include/state/time/TimeState.hpp
+++ b/libs/state/Include/state/time/TimeState.hpp
@@ -19,7 +19,7 @@ namespace state
     {
       public:
         /**
-         * @brief TimeState telemetry unique identifer.
+         * @brief TimeState telemetry unique identifier.
          */
         static constexpr int Id = 1;
 

--- a/libs/telemetry/CMakeLists.txt
+++ b/libs/telemetry/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(NAME telemetry)
+
+set(SOURCES
+    Include/telemetry/state.hpp
+)
+
+add_library(${NAME} STATIC ${SOURCES})
+
+target_link_libraries(${NAME}
+    base
+    logger
+    mission
+    state
+    comm
+)
+
+target_include_directories(${NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
+target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
+
+target_format_sources(${NAME} "${SOURCES}")
+
+add_subdirectory(comm)

--- a/libs/telemetry/Include/telemetry/Telemetry.hpp
+++ b/libs/telemetry/Include/telemetry/Telemetry.hpp
@@ -16,7 +16,7 @@
  *
  * @brief This module contains telemetry management routines.
  */
-namespace state
+namespace telemetry
 {
     namespace details
     {

--- a/libs/telemetry/Include/telemetry/fwd.hpp
+++ b/libs/telemetry/Include/telemetry/fwd.hpp
@@ -1,0 +1,16 @@
+#ifndef LIBS_TELEMETRY_FWD_HPP
+#define LIBS_TELEMETRY_FWD_HPP
+
+#pragma once
+
+#include "comm/comm.hpp"
+#include "state/fwd.hpp"
+
+namespace telemetry
+{
+    template <typename... Type> class Telemetry;
+
+    typedef Telemetry<state::TimeState, devices::comm::CommTelemetry> ManagedTelemetry;
+}
+
+#endif

--- a/libs/telemetry/Include/telemetry/state.hpp
+++ b/libs/telemetry/Include/telemetry/state.hpp
@@ -1,0 +1,19 @@
+#ifndef LIBS_TELEMETRY_STATE_HPP
+#define LIBS_TELEMETRY_STATE_HPP
+
+#pragma once
+
+#include "Telemetry.hpp"
+#include "comm/CommTelemetry.hpp"
+#include "fwd.hpp"
+#include "state/time/TimeState.hpp"
+
+namespace telemetry
+{
+    struct TelemetryState
+    {
+        ManagedTelemetry telemetry;
+    };
+}
+
+#endif

--- a/libs/telemetry/Include/telemetry/state.hpp
+++ b/libs/telemetry/Include/telemetry/state.hpp
@@ -10,8 +10,15 @@
 
 namespace telemetry
 {
+    /**
+     * @brief This type represents state of telemetry acquisition loop.
+     * @ingroup telemetry
+     */
     struct TelemetryState
     {
+        /**
+         * @brief Container for all telemetry elements currently collected by acquisition loop.
+         */
         ManagedTelemetry telemetry;
     };
 }

--- a/libs/telemetry/comm/CMakeLists.txt
+++ b/libs/telemetry/comm/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(NAME comm_telemetry)
+set(NAME telemetry_comm)
 
 set(SOURCES
     Include/telemetry/collect_comm.hpp

--- a/libs/telemetry/comm/CMakeLists.txt
+++ b/libs/telemetry/comm/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(NAME comm_telemetry)
+
+set(SOURCES
+    Include/telemetry/collect_comm.hpp
+    collect_comm.cpp
+)
+
+add_library(${NAME} STATIC ${SOURCES})
+
+target_link_libraries(${NAME}
+    base
+    logger
+    mission
+    state
+    comm
+    telemetry
+)
+
+target_include_directories(${NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
+target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Include/telemetry)
+
+target_format_sources(${NAME} "${SOURCES}")

--- a/libs/telemetry/comm/Include/telemetry/collect_comm.hpp
+++ b/libs/telemetry/comm/Include/telemetry/collect_comm.hpp
@@ -1,0 +1,33 @@
+#ifndef LIBS_TELEMETRY_COMM_COLLECT_HPP
+#define LIBS_TELEMETRY_COMM_COLLECT_HPP
+
+#pragma once
+
+#include "comm/comm.hpp"
+#include "mission/base.hpp"
+#include "telemetry/state.hpp"
+
+namespace telemetry
+{
+    class CommTelemetryAcquisition : public mission::Update
+    {
+      public:
+        CommTelemetryAcquisition(devices::comm::ICommTelemetryProvider& comm);
+
+        mission::UpdateDescriptor<telemetry::TelemetryState> BuildUpdate();
+
+        mission::UpdateResult UpdateCommTelemetry(telemetry::TelemetryState& state);
+
+      private:
+        /**
+         * @brief Updates current time in global mission state.
+         * @param[in] state Reference to global mission state.
+         * @param[in] param Current execution context.
+         */
+        static mission::UpdateResult UpdateProc(telemetry::TelemetryState& state, void* param);
+
+        devices::comm::ICommTelemetryProvider* provider;
+    };
+}
+
+#endif

--- a/libs/telemetry/comm/Include/telemetry/collect_comm.hpp
+++ b/libs/telemetry/comm/Include/telemetry/collect_comm.hpp
@@ -9,23 +9,44 @@
 
 namespace telemetry
 {
+    /**
+     * @brief This task is responsible for acquiring & updating comm hardware telemetry.
+     * @telemetry_acquisition
+     * @ingroup telemetry
+     */
     class CommTelemetryAcquisition : public mission::Update
     {
       public:
+        /**
+         * @brief ctor.
+         * @param[in] comm Reference to comm driver that will provide this module with hardware telemetry
+         */
         CommTelemetryAcquisition(devices::comm::ICommTelemetryProvider& comm);
 
+        /**
+         * @brief Builds update descriptor for this task.
+         * @return Update descriptor - the comm telemetry acquisition update task.
+         */
         mission::UpdateDescriptor<telemetry::TelemetryState> BuildUpdate();
 
+        /**
+         * @brief Acquires comm telemetry & stores it in passed state object.
+         * @param[in] state Object that should be updated with new comm hardware telemetry.
+         * @return Telemetry acquisition result.
+         */
         mission::UpdateResult UpdateCommTelemetry(telemetry::TelemetryState& state);
 
       private:
         /**
-         * @brief Updates current time in global mission state.
-         * @param[in] state Reference to global mission state.
+         * @brief Updates current comm telemetry in global state.
+         * @param[in] state Reference to global state.
          * @param[in] param Current execution context.
          */
         static mission::UpdateResult UpdateProc(telemetry::TelemetryState& state, void* param);
 
+        /**
+         * @brief Reference to comm driver.
+         */
         devices::comm::ICommTelemetryProvider* provider;
     };
 }

--- a/libs/telemetry/comm/collect_comm.cpp
+++ b/libs/telemetry/comm/collect_comm.cpp
@@ -1,0 +1,38 @@
+#include "collect_comm.hpp"
+#include "comm/CommTelemetry.hpp"
+#include "logger/logger.h"
+
+namespace telemetry
+{
+    CommTelemetryAcquisition::CommTelemetryAcquisition(devices::comm::ICommTelemetryProvider& comm) : provider(&comm)
+    {
+    }
+
+    mission::UpdateDescriptor<telemetry::TelemetryState> CommTelemetryAcquisition::BuildUpdate()
+    {
+        mission::UpdateDescriptor<telemetry::TelemetryState> descriptor;
+        descriptor.name = "Comm Telemetry Acquisition";
+        descriptor.updateProc = UpdateProc;
+        descriptor.param = this;
+        return descriptor;
+    }
+
+    mission::UpdateResult CommTelemetryAcquisition::UpdateCommTelemetry(telemetry::TelemetryState& state)
+    {
+        devices::comm::CommTelemetry telemetry;
+        if (!this->provider->GetTelemetry(telemetry))
+        {
+            LOG(LOG_LEVEL_ERROR, "Unable to acquire comm telemetry. ");
+            return mission::UpdateResult::Failure;
+        }
+
+        state.telemetry.Set(telemetry);
+        return mission::UpdateResult::Ok;
+    }
+
+    mission::UpdateResult CommTelemetryAcquisition::UpdateProc(telemetry::TelemetryState& state, void* param)
+    {
+        auto This = static_cast<CommTelemetryAcquisition*>(param);
+        return This->UpdateCommTelemetry(state);
+    }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(${NAME}
     watchdog
     boot_params
     telemetry
-    comm_telemetry
+    telemetry_comm
 )
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ target_link_libraries(${NAME}
     mission_comm
     watchdog
     boot_params
+    telemetry
+    comm_telemetry
 )
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gen)

--- a/src/mission.h
+++ b/src/mission.h
@@ -14,6 +14,8 @@
 #include "mission/telemetry.hpp"
 #include "mission/time.hpp"
 #include "state/struct.h"
+#include "telemetry/collect_comm.hpp"
+#include "telemetry/state.hpp"
 
 namespace mission
 {
@@ -25,12 +27,22 @@ namespace mission
         adcs::AdcsPrimaryTask,
         mission::experiments::MissionExperimentComponent,
         mission::BeaconUpdate,
-        mission::PeristentStateSave,
-        mission::TelemetryTask //
+        mission::PeristentStateSave //
         >
         ObcMission;
 }
 
+namespace telemetry
+{
+    typedef mission::MissionLoop<TelemetryState, //
+        CommTelemetryAcquisition,                //
+        mission::TelemetryTask                   //
+        >
+        ObcTelemetryAcquisition;
+}
+
 extern mission::ObcMission Mission;
+
+extern telemetry::ObcTelemetryAcquisition TelemetryAcquisition;
 
 #endif /* SRC_MISSION_H_ */

--- a/src/obc.h
+++ b/src/obc.h
@@ -66,8 +66,10 @@ struct OBC
 
     /** @brief File system object */
     services::fs::YaffsFileSystem fs;
+
     /** @brief Handle to OBC initialization task. */
     OSTaskHandle initTask;
+
     /** @brief Flag indicating that OBC software has finished initialization process. */
     EventGroup StateFlags;
 
@@ -121,9 +123,9 @@ LineIO& OBC::GetLineIO()
 {
 #ifdef USE_LEUART
     return this->IO;
-#endif
-
+#else
     return this->UARTDriver.GetLineIO();
+#endif
 }
 
 /** @brief Global OBC object. */

--- a/unit_tests/base/Include/mock/comm.hpp
+++ b/unit_tests/base/Include/mock/comm.hpp
@@ -4,13 +4,16 @@
 #include <cstdint>
 #include "gmock/gmock.h"
 #include "comm/Beacon.hpp"
+#include "comm/CommTelemetry.hpp"
 #include "comm/IBeaconController.hpp"
 #include "comm/ITransmitter.hpp"
+#include "comm/comm.hpp"
 #include "gsl/span"
 
 struct TransmitterMock : public devices::comm::ITransmitter
 {
     TransmitterMock();
+    ~TransmitterMock();
     MOCK_METHOD1(SendFrame, bool(gsl::span<const std::uint8_t>));
     MOCK_METHOD1(GetTransmitterTelemetry, bool(devices::comm::TransmitterTelemetry&));
     MOCK_METHOD1(SetTransmitterStateWhenIdle, bool(devices::comm::IdleState));
@@ -22,8 +25,16 @@ struct TransmitterMock : public devices::comm::ITransmitter
 struct BeaconControllerMock : public devices::comm::IBeaconController
 {
     BeaconControllerMock();
+    ~BeaconControllerMock();
     MOCK_METHOD1(SetBeacon, Option<bool>(const devices::comm::Beacon& beacon));
     MOCK_METHOD0(ClearBeacon, bool());
+};
+
+struct CommTelemetryProviderMock : public devices::comm::ICommTelemetryProvider
+{
+    CommTelemetryProviderMock();
+    ~CommTelemetryProviderMock();
+    MOCK_METHOD1(GetTelemetry, bool(devices::comm::CommTelemetry& telemetry));
 };
 
 #endif /* UNIT_TESTS_MOCK_COMM_HPP_ */

--- a/unit_tests/base/mock/comm.cpp
+++ b/unit_tests/base/mock/comm.cpp
@@ -4,6 +4,22 @@ TransmitterMock::TransmitterMock()
 {
 }
 
+TransmitterMock::~TransmitterMock()
+{
+}
+
 BeaconControllerMock::BeaconControllerMock()
+{
+}
+
+BeaconControllerMock::~BeaconControllerMock()
+{
+}
+
+CommTelemetryProviderMock::CommTelemetryProviderMock()
+{
+}
+
+CommTelemetryProviderMock::~CommTelemetryProviderMock()
 {
 }

--- a/unit_tests/mission/MissionPlan/TelemetryTest.cpp
+++ b/unit_tests/mission/MissionPlan/TelemetryTest.cpp
@@ -26,11 +26,11 @@ namespace
 
         IOResult WriteSuccessful();
 
-        SystemState state;
+        telemetry::TelemetryState state;
         testing::NiceMock<FsMock> fs;
         mission::TelemetryConfiguration config;
         mission::TelemetryTask task;
-        mission::ActionDescriptor<SystemState> descriptor;
+        mission::ActionDescriptor<telemetry::TelemetryState> descriptor;
     };
 
     TelemetryTest::TelemetryTest()

--- a/unit_tests/state/CMakeLists.txt
+++ b/unit_tests/state/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
   state/AntennaConfigTest.cpp
   state/TelemetryTest.cpp
   obc/ObcStateTest.cpp 
+  telemetry/CommTelemetryAcquisitionTest.cpp
 )
 
 add_unit_tests(${NAME} ${SOURCES})
@@ -15,6 +16,7 @@ target_link_libraries(${NAME}
     unit_tests_base
     state
     telemetry
+    telemetry_comm
 )
 
 

--- a/unit_tests/state/CMakeLists.txt
+++ b/unit_tests/state/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(${NAME}
     obc_state
     unit_tests_base
     state
+    telemetry
 )
 
 

--- a/unit_tests/state/state/TelemetryTest.cpp
+++ b/unit_tests/state/state/TelemetryTest.cpp
@@ -2,7 +2,7 @@
 #include "gmock/gmock-matchers.h"
 #include "base/reader.h"
 #include "base/writer.h"
-#include "state/Telemetry.hpp"
+#include "telemetry/Telemetry.hpp"
 
 namespace
 {
@@ -130,7 +130,7 @@ namespace
         return this->byte;
     }
 
-    typedef state::Telemetry<SimpleObject, ComplexObject> Telemetry;
+    typedef telemetry::Telemetry<SimpleObject, ComplexObject> Telemetry;
 
     class TelemetryTest : public testing::Test
     {

--- a/unit_tests/state/telemetry/CommTelemetryAcquisitionTest.cpp
+++ b/unit_tests/state/telemetry/CommTelemetryAcquisitionTest.cpp
@@ -1,0 +1,61 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock-matchers.h"
+#include "mission/base.hpp"
+#include "mock/comm.hpp"
+#include "telemetry/collect_comm.hpp"
+#include "telemetry/state.hpp"
+
+namespace
+{
+    using testing::Return;
+    using testing::_;
+    using testing::Eq;
+    using testing::Ne;
+    using testing::Invoke;
+
+    using namespace devices::comm;
+    class CommTelemetryAcquisitionTest : public testing::Test
+    {
+      protected:
+        CommTelemetryAcquisitionTest();
+        mission::UpdateResult Run();
+        CommTelemetryProviderMock comm;
+        telemetry::TelemetryState state;
+        telemetry::CommTelemetryAcquisition task;
+        mission::UpdateDescriptor<telemetry::TelemetryState> descriptor;
+    };
+
+    CommTelemetryAcquisitionTest::CommTelemetryAcquisitionTest() : task(comm), descriptor(task.BuildUpdate())
+    {
+    }
+
+    mission::UpdateResult CommTelemetryAcquisitionTest::Run()
+    {
+        return descriptor.Execute(state);
+    }
+
+    TEST_F(CommTelemetryAcquisitionTest, TestAcquisitionFailure)
+    {
+        EXPECT_CALL(comm, GetTelemetry(_)).WillOnce(Return(false));
+        const auto result = Run();
+        ASSERT_THAT(result, Ne(mission::UpdateResult::Ok));
+        ASSERT_THAT(state.telemetry.IsModified(), Eq(false));
+    }
+
+    TEST_F(CommTelemetryAcquisitionTest, TestAcquisition)
+    {
+        EXPECT_CALL(comm, GetTelemetry(_)).WillOnce(Return(true));
+        const auto result = Run();
+        ASSERT_THAT(result, Eq(mission::UpdateResult::Ok));
+    }
+
+    TEST_F(CommTelemetryAcquisitionTest, TestAcquisitionStateUpdate)
+    {
+        EXPECT_CALL(comm, GetTelemetry(_)).WillOnce(Invoke([](auto& telemetry) {
+            telemetry = CommTelemetry({}, {}, {IdleState::On, Bitrate::Comm2400bps, true});
+            return true;
+        }));
+        Run();
+        ASSERT_THAT(state.telemetry.IsModified(), Eq(true));
+    }
+}


### PR DESCRIPTION
Add task that is responsible for querying devices for their current telemetry & store it using in available telemetry container.  This change also includes separation of telemetry acquisition from main mission loop as the telemetry acquisition process should not be interrupted with tasks that have undetermined execution which could significantly affect telemetry collection frequency. 

The only potentially long running task in telemetry acquisition is task that is responsible for serializing current telemetry state and save it to file. 

The acquisition process itself is based on the same mechanism as the main mission loop, the only difference is that both tasks loops are using different state objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/149)
<!-- Reviewable:end -->
