### PR TITLE
use memcmp for TMR compare instead of span compare

### DIFF
--- a/libs/drivers/n25q/redundant_n25q.cpp
+++ b/libs/drivers/n25q/redundant_n25q.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <cstring>
 
 #include "base/os.h"
 
@@ -32,7 +33,9 @@ void RedundantN25QDriver::ReadMemory(    //
     _n25qDrivers[0]->ReadMemory(address, normalizedOutputBuffer);
     _n25qDrivers[1]->ReadMemory(address, normalizedRedundantBuffer1);
 
-    if (normalizedOutputBuffer == normalizedRedundantBuffer1)
+    auto compareResult = memcmp(normalizedOutputBuffer.data(), normalizedRedundantBuffer1.data(), normalizedOutputBuffer.size()) == 0;
+
+    if (compareResult)
     {
         return;
     }


### PR DESCRIPTION
`memcmp` is about 45 times faster than span compare

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/159)
<!-- Reviewable:end -->
