### PR TITLE
Refactored logs generated by integration tests

### DIFF
--- a/integration_tests/devices/comm.py
+++ b/integration_tests/devices/comm.py
@@ -195,18 +195,15 @@ class TransmitterDevice(i2cMock.I2CDevice):
     
     @i2cMock.command([0xAA])
     def _reset(self):
-        self.log.info("Reset")
         call(self.on_reset, None)
         self.reset()
 
     @i2cMock.command([0xAB])
     def _hwreset(self):
-        self.log.info("Hardware Reset")
         call(self.on_hardware_reset, None)
 
     @i2cMock.command([0xCC])
     def _watchdog_reset(self):
-        self.log.info("Watchdog Reset")
         call(self.on_watchdog_reset, None)
 
     @i2cMock.command([0x10])
@@ -298,18 +295,15 @@ class ReceiverDevice(i2cMock.I2CDevice):
 
     @i2cMock.command([0xAA])
     def _reset(self):
-        self.log.info("Reset")
         call(self.on_reset, None)
         self.reset()
 
     @i2cMock.command([0xAB])
     def _hwreset(self):
-        self.log.info("Hardware reset")
         call(self.on_hardware_reset, None)
 
     @i2cMock.command([0xCC])
     def _watchdog_reset(self):
-        self.log.info("Watchdog Reset")
         call(self.on_watchdog_reset, None)
 
     @i2cMock.command([0x21])

--- a/integration_tests/obc/SerialPortTerminal.py
+++ b/integration_tests/obc/SerialPortTerminal.py
@@ -68,7 +68,7 @@ class SerialPortTerminal:
         self._command_prologue(cmd)
 
         response = self.readUntilPrompt().rstrip('\n')
-        self.log.debug("Command " + cmd + " responded with '" + response + "'")
+        self.log.info("Command " + cmd + " responded with '" + response + "'")
         return response
 
     def command_no_wait(self, cmd):


### PR DESCRIPTION
 - Fixed device address in I2C logs - it was shifted by 1 bit.
 - When I2C mock handles incoming request, it logs the device and handler name, i.e.:

```2017-06-11 16:15:29,579 DEBUG: [I2C] Received command 42 (['C0', '21'])
2017-06-11 16:15:29,581 DEBUG: [I2C.BUS] Device(0x60) write(['21'])
2017-06-11 16:15:29,582 INFO: [Device 0x60] ReceiverDevice._get_number_of_frames([])
```

 - Changed log levels so that only by looking at info it's easy to see what's going on - I2C logs are all `debug`, only new handler log with readable names is `info`. Also terminal commands are `info` instead of `debug`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/182)
<!-- Reviewable:end -->
