### PR TITLE
IO map fix - payload pfm 1.01 and 2.02 have wrong pin naming

### DIFF
--- a/platforms/mcu/EngModel/Include/mcu/io_map.h
+++ b/platforms/mcu/EngModel/Include/mcu/io_map.h
@@ -22,11 +22,11 @@ namespace io_map
     using SystickIndicator = PinLocation<gpioPortD, 1>;
     using BootIndicator = PinLocation<gpioPortD, 2>;
 
-    using SailDeployed = PinLocation<gpioPortD, 4>;
+    using SailDeployed = PinLocation<gpioPortD, 5>;
 
     using CamSelect = PiggyBack22;
 
-    using SunsInterrupt = PinLocation<gpioPortD, 5>;
+    using SunsInterrupt = PinLocation<gpioPortD, 7>;
 
     struct SPI : public SPIPins<SPI>
     {

--- a/platforms/mcu/FlightModel/Include/mcu/io_map.h
+++ b/platforms/mcu/FlightModel/Include/mcu/io_map.h
@@ -22,11 +22,11 @@ namespace io_map
     using SystickIndicator = PinLocation<gpioPortD, 1>;
     using BootIndicator = PinLocation<gpioPortD, 2>;
 
-    using SailDeployed = PinLocation<gpioPortD, 4>;
+    using SailDeployed = PinLocation<gpioPortD, 5>;
 
     using CamSelect = PiggyBack22;
 
-    using SunsInterrupt = PinLocation<gpioPortD, 5>;
+    using SunsInterrupt = PinLocation<gpioPortD, 7>;
 
     struct SPI : public SPIPins<SPI>
     {


### PR DESCRIPTION
IO map fix - payload pfm 1.01 and 2.02 have wrong pin naming details can be found here: https://team.pw-sat.pl/F5527 and https://team.pw-sat.pl/w/pld/pfm/#important-issue-for-both)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/234)
<!-- Reviewable:end -->
