### PR TITLE
Experiment file parser

### DIFF
--- a/integration_tests/experiment_file/__init__.py
+++ b/integration_tests/experiment_file/__init__.py
@@ -1,0 +1,19 @@
+from parsec import many
+
+from base import Synchronization, Timestamp, Padding
+from suns import ExperimentalSunSPrimary, ExperimentalSunSSecondary, ReferenceSunS
+from gyro import Gyro
+
+pids = Synchronization \
+       ^ Timestamp \
+       ^ Padding \
+       ^ ExperimentalSunSPrimary \
+       ^ ExperimentalSunSSecondary \
+       ^ ReferenceSunS \
+       ^ Gyro
+
+ExperimentFileParser = many(pids)
+
+__all__ = [
+    'ExperimentFileParser'
+]

--- a/integration_tests/experiment_file/base.py
+++ b/integration_tests/experiment_file/base.py
@@ -1,5 +1,6 @@
 import struct
 from binascii import hexlify
+from datetime import timedelta
 
 from parsec import *
 
@@ -49,9 +50,22 @@ def label_as(name):
     return as_dict
 
 
+def to_dict(value):
+    # if len(value) > 1:
+    return Parser(lambda _, index: Value.success(index, dict(value)))
+    # else:
+
+
+
+def field(name, content_parser):
+    return content_parser.parsecmap(lambda v: (name, v))
+
+
+uint16 = packed('<H')
+
 Synchronization = pid(0x47).result('Synchronization')
 
-Timestamp = pid(1) >> packed('<Q')
+Timestamp = pid(1) >> packed('<Q').parsecmap(lambda x: timedelta(milliseconds=x))
 Timestamp >>= label_as('time')
 
 Padding = many1(pid(0xFF)).parsecmap(lambda x: len(x))

--- a/integration_tests/experiment_file/base.py
+++ b/integration_tests/experiment_file/base.py
@@ -1,4 +1,5 @@
 import struct
+from binascii import hexlify
 
 from parsec import *
 
@@ -23,7 +24,7 @@ def byte(text, index=0):
 
 
 def bytes_block(n):
-    return count(byte, n).parsecmap(lambda x: ''.join(x))
+    return count(byte, n).parsecmap(lambda x: ''.join(x)).parsecmap(hexlify)
 
 
 def packed(fmt):

--- a/integration_tests/experiment_file/base.py
+++ b/integration_tests/experiment_file/base.py
@@ -1,0 +1,57 @@
+import struct
+
+from parsec import *
+
+
+def pid(n):
+    @Parser
+    def match_pid(text, index=0):
+        if index < len(text) and text[index] == chr(n):
+            return Value.success(index + 1, text[index])
+        else:
+            return Value.failure(index, 'PID {:02X}'.format(n))
+
+    return match_pid
+
+
+@Parser
+def byte(text, index=0):
+    if index < len(text):
+        return Value.success(index + 1, text[index])
+    else:
+        return Value.failure(index, 'a byte')
+
+
+def bytes_block(n):
+    return count(byte, n).parsecmap(lambda x: ''.join(x))
+
+
+def packed(fmt):
+    size = struct.calcsize(fmt)
+
+    @Parser
+    def unpack(text, index=0):
+        if index + size < len(text):
+            part = text[index: index + size]
+            unpacked = struct.unpack(fmt, part)
+            return Value.success(index + size, unpacked[0])
+        else:
+            return Value.failure(index, 'Packed value: {}'.format(fmt))
+
+    return unpack
+
+
+def label_as(name):
+    def as_dict(value):
+        return Parser(lambda _, index: Value.success(index, {name: value}))
+
+    return as_dict
+
+
+Synchronization = pid(0x47).result('Synchronization')
+
+Timestamp = pid(1) >> packed('<Q')
+Timestamp >>= label_as('time')
+
+Padding = many1(pid(0xFF)).parsecmap(lambda x: len(x))
+Padding >>= label_as('Padding')

--- a/integration_tests/experiment_file/gyro.py
+++ b/integration_tests/experiment_file/gyro.py
@@ -1,4 +1,10 @@
-from base import pid, bytes_block, label_as
+from base import pid, label_as, joint, field, uint16, to_dict
 
-Gyro = pid(0x10) >> bytes_block(8)
+Gyro = pid(0x10) >> \
+    joint(
+        field('X', uint16),
+        field('Y', uint16),
+        field('Z', uint16),
+        field('Temperature', uint16)
+    ).bind(to_dict)
 Gyro >>= label_as('Gyro')

--- a/integration_tests/experiment_file/gyro.py
+++ b/integration_tests/experiment_file/gyro.py
@@ -1,0 +1,4 @@
+from base import pid, bytes_block, label_as
+
+Gyro = pid(0x10) >> bytes_block(8)
+Gyro >>= label_as('Gyro')

--- a/integration_tests/experiment_file/suns.py
+++ b/integration_tests/experiment_file/suns.py
@@ -1,6 +1,6 @@
 from base import pid, bytes_block, label_as
 
-ExperimentalSunSPrimary = pid(0x11) >> bytes_block(39)
+ExperimentalSunSPrimary = pid(0x11) >> bytes_block(41)
 ExperimentalSunSPrimary >>= label_as('ExpSunS.Primary')
 
 ExperimentalSunSSecondary = pid(0x12) >> bytes_block(26)

--- a/integration_tests/experiment_file/suns.py
+++ b/integration_tests/experiment_file/suns.py
@@ -1,0 +1,10 @@
+from base import pid, bytes_block, label_as
+
+ExperimentalSunSPrimary = pid(0x11) >> bytes_block(39)
+ExperimentalSunSPrimary >>= label_as('ExpSunS.Primary')
+
+ExperimentalSunSSecondary = pid(0x12) >> bytes_block(26)
+ExperimentalSunSSecondary >>= label_as('ExpSunS.Secondary')
+
+ReferenceSunS = pid(0x13) >> bytes_block(10)
+ReferenceSunS >>= label_as('RefSunS')

--- a/integration_tests/experiment_file/suns.py
+++ b/integration_tests/experiment_file/suns.py
@@ -1,10 +1,47 @@
-from base import pid, bytes_block, label_as
+from parsec import joint
 
-ExperimentalSunSPrimary = pid(0x11) >> bytes_block(41)
+from base import pid, bytes_block, label_as, field, to_dict, byte, uint16, count
+
+ExperimentalSunSStatus = joint(
+    field('ALS_ACK', uint16),
+    field('ALS_Presence', uint16),
+    field('ALS_ADC_Valid', uint16),
+)
+ExperimentalSunSStatus >>= to_dict
+
+SingleALS = count(uint16, 4)
+
+ALSs = count(SingleALS, 3)
+
+Temperatures = joint(
+    field('Structure', uint16),
+    field('A', uint16),
+    field('B', uint16),
+    field('C', uint16),
+    field('D', uint16),
+).bind(to_dict)
+
+ExperimentalSunSPrimary = pid(0x11) \
+                          >> joint(
+                            field('WhoAmI ', byte.parsecmap(ord)),
+                            field('Status', ExperimentalSunSStatus),
+                            field('VisibleLight', ALSs),
+                            field('Temperatures', Temperatures),
+                          ).bind(to_dict)
 ExperimentalSunSPrimary >>= label_as('ExpSunS.Primary')
 
-ExperimentalSunSSecondary = pid(0x12) >> bytes_block(26)
+ExperimentalSunSSecondary = pid(0x12) \
+                            >> joint(
+                                field('Parameters',
+                                      joint(
+                                          field('gain', byte.parsecmap(ord)),
+                                          field('itime', byte.parsecmap(ord))
+                                      ).bind(to_dict)
+                                ),
+                                field('Infrared', ALSs)
+                            ).bind(to_dict)
 ExperimentalSunSSecondary >>= label_as('ExpSunS.Secondary')
 
-ReferenceSunS = pid(0x13) >> bytes_block(10)
+ReferenceSunS = pid(0x13) \
+                >> joint(field('Volatages', count(uint16, 5))).bind(to_dict)
 ReferenceSunS >>= label_as('RefSunS')

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -7,3 +7,4 @@ nose-parameterized
 bitarray
 pypiwin32; sys_platform == 'win32'
 typing
+parsec

--- a/integration_tests/tools/read_exp_file.py
+++ b/integration_tests/tools/read_exp_file.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from binascii import hexlify
+import pprint
 
 try:
     from experiment_file import ExperimentFileParser
@@ -25,7 +26,7 @@ result = ExperimentFileParser.parse_partial(read_all(args.file))
 
 print 'Parsed data:'
 for p in result[0]:
-    print p
+    pprint.pprint(p)
 
 if len(result[1]) > 0:
     print 'Remaining data (first 10 bytes, total {} not parsed)'.format(len(result[1]))

--- a/integration_tests/tools/read_exp_file.py
+++ b/integration_tests/tools/read_exp_file.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+import sys
+from binascii import hexlify
+
+try:
+    from experiment_file import ExperimentFileParser
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+    from experiment_file import ExperimentFileParser
+
+
+def read_all(p):
+    with open(p, 'rb') as f:
+        return f.read()
+
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('file', help="File with experiment data")
+
+args = argparser.parse_args()
+
+
+result = ExperimentFileParser.parse_partial(read_all(args.file))
+
+print 'Parsed data:'
+for p in result[0]:
+    print p
+
+if len(result[1]) > 0:
+    print 'Remaining data (first 10 bytes, total {} not parsed)'.format(len(result[1]))
+    part = result[1][0:min(10, len(result[1]))]
+    print hexlify(part)
+else:
+    print ''

--- a/libs/drivers/suns/Include/suns/suns.hpp
+++ b/libs/drivers/suns/Include/suns/suns.hpp
@@ -71,7 +71,7 @@ namespace devices
         using Panels = std::array<std::uint16_t, 4>;
 
         /**
-         * @brief Array containing four panel light readings.
+         * @brief Array containing three panel light readings.
          */
         using LightData = std::array<Als, 3>;
 

--- a/libs/experiments/suns/suns.cpp
+++ b/libs/experiments/suns/suns.cpp
@@ -193,6 +193,7 @@ namespace experiment
                 w.WriteWordLE(this->ExperimentalSunS.temperature.panels[0]);
                 w.WriteWordLE(this->ExperimentalSunS.temperature.panels[1]);
                 w.WriteWordLE(this->ExperimentalSunS.temperature.panels[2]);
+                w.WriteWordLE(this->ExperimentalSunS.temperature.panels[3]);
 
                 file.Write(ExperimentFile::PID::ExperimentalSunSPrimary, w.Capture());
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(pulse_all)
 add_subdirectory(flash)
 add_subdirectory(fm_terminal)
+add_subdirectory(generate_exp_data)

--- a/test/generate_exp_data/CMakeLists.txt
+++ b/test/generate_exp_data/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(${NAME}
 	base
 	platform
 	emlib
+	fs
 )
 
 set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-T ${CMAKE_SOURCE_DIR}/unit_tests/base/linker.ld -u _printf_float -specs=rdimon.specs")

--- a/test/generate_exp_data/CMakeLists.txt
+++ b/test/generate_exp_data/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(NAME generate_exp_data)
+
+set(SOURCES
+    main.cpp
+)
+
+add_executable(${NAME} ${SOURCES})
+
+target_link_libraries(${NAME} 
+	base
+	platform
+	emlib
+)
+
+set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-T ${CMAKE_SOURCE_DIR}/unit_tests/base/linker.ld -u _printf_float -specs=rdimon.specs")
+
+set (EXEC_OBJ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${NAME})
+add_custom_target(${NAME}.run
+  COMMAND ${QEMU} -board generic -mcu ${QEMU_MCU} -nographic -monitor null -image ${EXEC_OBJ} -semihosting-config "arg=tests"
+
+  DEPENDS ${NAME}
+)    

--- a/test/generate_exp_data/CMakeLists.txt
+++ b/test/generate_exp_data/CMakeLists.txt
@@ -2,6 +2,7 @@ set(NAME generate_exp_data)
 
 set(SOURCES
     main.cpp
+    suns_data.cpp
 )
 
 add_executable(${NAME} ${SOURCES})
@@ -11,6 +12,7 @@ target_link_libraries(${NAME}
 	platform
 	emlib
 	fs
+	exp_suns
 )
 
 set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-T ${CMAKE_SOURCE_DIR}/unit_tests/base/linker.ld -u _printf_float -specs=rdimon.specs")

--- a/test/generate_exp_data/main.cpp
+++ b/test/generate_exp_data/main.cpp
@@ -1,17 +1,11 @@
 #include <array>
 #include <cstdio>
 #include <unistd.h>
+#include "base/os.h"
 #include "fs/fs.h"
 #include "utils.h"
 
 using namespace services::fs;
-
-void GenerateSunSData(IFileSystem& fs)
-{
-    File f(fs, "test.txt", FileOpen::CreateNew, FileAccess::ReadWrite);
-    std::array<std::uint8_t, 4> buf{65, 66, 67, 68};
-    f.Write(buf);
-}
 
 extern "C" {
 extern void initialise_monitor_handles(void);
@@ -134,6 +128,12 @@ class PosixFileSystem : public IFileSystem
         return 0;
     }
 };
+
+extern void GenerateSunSData(IFileSystem& fs);
+
+void System::SleepTask(std::chrono::milliseconds)
+{
+}
 
 int main()
 {

--- a/test/generate_exp_data/main.cpp
+++ b/test/generate_exp_data/main.cpp
@@ -1,4 +1,17 @@
+#include <array>
 #include <cstdio>
+#include <unistd.h>
+#include "fs/fs.h"
+#include "utils.h"
+
+using namespace services::fs;
+
+void GenerateSunSData(IFileSystem& fs)
+{
+    File f(fs, "test.txt", FileOpen::CreateNew, FileAccess::ReadWrite);
+    std::array<std::uint8_t, 4> buf{65, 66, 67, 68};
+    f.Write(buf);
+}
 
 extern "C" {
 extern void initialise_monitor_handles(void);
@@ -6,13 +19,131 @@ extern void __libc_init_array(void);
 extern int kill(pid_t, int);
 }
 
+class PosixFileSystem : public IFileSystem
+{
+  public:
+    virtual FileOpenResult Open(const char* path, FileOpen openFlag, FileAccess accessMode) override
+    {
+        auto f = open(path, num(openFlag), num(accessMode));
+
+        if (f == -1)
+        {
+            return FileOpenResult(static_cast<OSResult>(errno), -1);
+        }
+        else
+        {
+            return FileOpenResult(OSResult::Success, f);
+        }
+    }
+
+    virtual OSResult Unlink(const char* /*path*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual OSResult Move(const char* /*from*/, const char* /*to*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual OSResult TruncateFile(FileHandle /*file*/, FileSize /*length*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual IOResult Write(FileHandle file, gsl::span<const std::uint8_t> buffer) override
+    {
+        auto r = write(file, buffer.data(), buffer.size());
+
+        if (r == -1)
+        {
+            return IOResult(static_cast<OSResult>(errno), {});
+        }
+        else
+        {
+            return IOResult(OSResult::Success, buffer.subspan(0, r));
+        }
+    }
+
+    virtual IOResult Read(FileHandle file, gsl::span<std::uint8_t> buffer) override
+    {
+        auto r = read(file, buffer.data(), buffer.size());
+
+        if (r == -1)
+        {
+            return IOResult(static_cast<OSResult>(errno), {});
+        }
+        else
+        {
+            return IOResult(OSResult::Success, buffer.subspan(0, r));
+        }
+    }
+
+    virtual OSResult Close(FileHandle file) override
+    {
+        return static_cast<OSResult>(close(file));
+    }
+
+    virtual DirectoryOpenResult OpenDirectory(const char* /*dirname*/) override
+    {
+        return DirectoryOpenResult(OSResult::NotSupported, 0);
+    }
+
+    virtual char* ReadDirectory(DirectoryHandle /*directory*/) override
+    {
+        return nullptr;
+    }
+
+    virtual OSResult CloseDirectory(DirectoryHandle /*directory*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual OSResult Format(const char* /*mountPoint*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual OSResult MakeDirectory(const char* /*path*/) override
+    {
+        return OSResult::NotSupported;
+    }
+
+    virtual bool Exists(const char* /*path*/) override
+    {
+        return false;
+    }
+
+    virtual FileSize GetFileSize(FileHandle /*file*/) override
+    {
+        return 0;
+    }
+
+    virtual FileSize GetFileSize(const char* /*dir*/, const char* /*file*/) override
+    {
+        return 0;
+    }
+
+    virtual OSResult Seek(FileHandle file, SeekOrigin origin, FileSize offset) override
+    {
+        return static_cast<OSResult>(lseek(file, offset, num(origin)));
+    }
+
+    virtual std::uint32_t GetFreeSpace(const char* /*devicePath*/) override
+    {
+        return 0;
+    }
+};
+
 int main()
 {
     __libc_init_array();
 
     initialise_monitor_handles();
 
-    printf("test\n");
+    PosixFileSystem fs;
+
+    GenerateSunSData(fs);
 
     kill(-1, 0);
 

--- a/test/generate_exp_data/main.cpp
+++ b/test/generate_exp_data/main.cpp
@@ -1,0 +1,20 @@
+#include <cstdio>
+
+extern "C" {
+extern void initialise_monitor_handles(void);
+extern void __libc_init_array(void);
+extern int kill(pid_t, int);
+}
+
+int main()
+{
+    __libc_init_array();
+
+    initialise_monitor_handles();
+
+    printf("test\n");
+
+    kill(-1, 0);
+
+    return 0;
+}

--- a/test/generate_exp_data/suns_data.cpp
+++ b/test/generate_exp_data/suns_data.cpp
@@ -1,0 +1,52 @@
+#include "experiment/suns/suns.hpp"
+#include "fs/fs.h"
+
+using namespace services::fs;
+using namespace std::chrono_literals;
+using experiments::fs::ExperimentFile;
+
+void GenerateSunSData(IFileSystem& fs)
+{
+    experiment::suns::DataPoint data;
+
+    memset(&data, 0, sizeof(data));
+
+    data.Timestamp = 1234ms;
+
+    data.ExperimentalSunS.status = {0x3333, 0x1111, 0x2222};
+    data.ExperimentalSunS.parameters = {0x44, 0x55};
+
+    data.ExperimentalSunS.visible_light = {{
+        {{0xA0A0, 0xA1A1, 0xA2A2, 0xA3A3}}, //
+        {{0xB0B0, 0xB1B1, 0xB2B2, 0xB3B3}}, //
+        {{0xC0C0, 0xC1C1, 0xC2C2, 0xC3C3}}, //
+    }};
+
+    data.ExperimentalSunS.temperature.structure = {0x6666};
+    data.ExperimentalSunS.temperature.panels = {0x7777, 0x8888, 0x9999, 0xAAAA};
+
+    data.ExperimentalSunS.infrared = {{
+        {{0xAEAE, 0xAAAA, 0xABAB, 0xACAC}}, //
+        {{0xBEBE, 0xBABA, 0xBBBB, 0xBCBC}}, //
+        {{0xCECE, 0xCACA, 0xCBCB, 0xCCCC}}, //
+    }};
+
+    data.ReferenceSunS.voltages = {{0xE0E0, 0xE1E1, 0xE2E2, 0xE3E3, 0xE4E4}};
+    data.Gyro = {0x0F1F, 0x2F3F, 0x4F5F, 0x6F7F};
+
+    ExperimentFile primary;
+
+    primary.Open(fs, "suns_primary", FileOpen::CreateAlways, FileAccess::ReadWrite);
+
+    data.WritePrimaryDataSetTo(primary);
+
+    primary.Close();
+
+    ExperimentFile secondary;
+
+    secondary.Open(fs, "suns_secondary", FileOpen::CreateAlways, FileAccess::ReadWrite);
+
+    data.WriteSecondaryDataSetTo(secondary);
+
+    secondary.Close();
+}

--- a/unit_tests/properties/Experiments/SunSDataPointTest.cpp
+++ b/unit_tests/properties/Experiments/SunSDataPointTest.cpp
@@ -151,6 +151,7 @@ namespace
         w.WriteWordLE(point.ExperimentalSunS.temperature.panels[0]);
         w.WriteWordLE(point.ExperimentalSunS.temperature.panels[1]);
         w.WriteWordLE(point.ExperimentalSunS.temperature.panels[2]);
+        w.WriteWordLE(point.ExperimentalSunS.temperature.panels[3]);
 
         w.WriteByte(num(ExperimentFile::PID::ReferenceSunS));
         for (auto v : point.ReferenceSunS.voltages)


### PR DESCRIPTION
1) Fix for SunS experiment data (one temperature was missing)
2) Experiment file parser. Sample output:
```
Parsed data:
'Synchronization'
{'time': datetime.timedelta(0, 1, 234000)}
{'ExpSunS.Primary': {'Status': {'ALS_ACK': 13107,
                                'ALS_ADC_Valid': 8738,
                                'ALS_Presence': 4369},
                     'Temperatures': {'A': 30583,
                                      'B': 34952,
                                      'C': 39321,
                                      'D': 43690,
                                      'Structure': 26214},
                     'VisibleLight': [[41120, 41377, 41634, 41891],
                                      [45232, 45489, 45746, 46003],
                                      [49344, 49601, 49858, 50115]],
                     'WhoAmI ': 17}}
{'RefSunS': {'Volatages': [57568, 57825, 58082, 58339, 58596]}}
{'Gyro': {'Temperature': 28543, 'X': 3871, 'Y': 12095, 'Z': 20319}}
{'Padding': 159}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/250)
<!-- Reviewable:end -->
