### PR TITLE
EPS HK/UPTIME printf specifier fix in OBC terminal

### DIFF
--- a/src/commands/eps.cpp
+++ b/src/commands/eps.cpp
@@ -68,7 +68,7 @@ static void Print(const char* prefix, const devices::eps::hk::ThisControllerStat
 {
     GetTerminal().Printf("%s.SAFETY_CTR\t%d\n", prefix, hk.safetyCounter);
     GetTerminal().Printf("%s.PWR_CYCLES\t%d\n", prefix, hk.powerCycleCount);
-    GetTerminal().Printf("%s.UPTIME\t%ld\n", prefix, hk.uptime);
+    GetTerminal().Printf("%s.UPTIME\t%lu\n", prefix, hk.uptime);
     GetTerminal().Printf("%s.TEMP\t%d\n", prefix, hk.temperature.Value());
     GetTerminal().Printf("%s.SUPP_TEMP\t%d\n", prefix, hk.suppTemp.Value());
 }


### PR DESCRIPTION
0xFFFF was printed as -1 in OBC terminal (long uint conversion to long int). This number should be printed as 4294967295. The %lu instead of %ld printf specifier fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/252)
<!-- Reviewable:end -->
