### PR TITLE
[experiments][sail] Purge pending photo service commands at the end of experiment.

### DIFF
--- a/libs/experiments/sail/sail.cpp
+++ b/libs/experiments/sail/sail.cpp
@@ -307,6 +307,7 @@ namespace experiment
 
         void SailExperiment::FinalizeExperiment()
         {
+            this->_photoService.PurgePendingCommands();
             TakePhoto(services::photo::Camera::Wing, services::photo::PhotoResolution::p480);
             TakePhoto(services::photo::Camera::Nadir, services::photo::PhotoResolution::p480);
         }


### PR DESCRIPTION
Necessary in case of delays caused by the communication problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/267)
<!-- Reviewable:end -->
