### PR TITLE
[Emulator Addons] Simulated frame sending and parsing time.

### DIFF
--- a/integration_tests/emulator/beacon.py
+++ b/integration_tests/emulator/beacon.py
@@ -9,7 +9,8 @@ from wx import propgrid
 
 class BeaconModule(ModuleBase):
     type_to_property = {
-        int: propgrid.IntProperty
+        int: propgrid.IntProperty,
+        str: propgrid.StringProperty
     }
 
     def __init__(self, last_beacon, system):

--- a/integration_tests/emulator/beacon.py
+++ b/integration_tests/emulator/beacon.py
@@ -59,10 +59,10 @@ class BeaconModule(ModuleBase):
                     existing_property.SetValue(value)
 
     def update(self):
-        if self._system.transmitter.current_beacon_timestamp is not None:
+        if self._last_beacon.payload is not None:
             store = BeaconStorage()
             parser = BitArrayParser(FullBeaconParser(),
-                                    ''.join(map(lambda x: pack('B', x), self._system.transmitter.current_beacon)),
+                                    ''.join(map(lambda x: pack('B', x), self._last_beacon.payload)),
                                     store)
             parser.parse()
 

--- a/integration_tests/emulator/beacon_parser/parser.py
+++ b/integration_tests/emulator/beacon_parser/parser.py
@@ -1,4 +1,4 @@
-from utils import bits_to_dword, bits_to_byte, bits_to_word, bits_to_qword
+from utils import bits_to_dword, bits_to_byte, bits_to_word, bits_to_qword, call
 from bitarray import bitarray
 
 
@@ -61,21 +61,22 @@ class CategoryParser:
         self._reader = reader
         self._store = store
 
-    def append(self, name, length):
+    def append(self, name, length, type_converter = None):
         value = self._reader.read(length)
-        self._store.write(self._category, self._format_name(name, length), value)
+        converted_value = call(type_converter, value, value)
+        self._store.write(self._category, self._format_name(name, length), converted_value)
 
-    def append_byte(self, name):
-        self.append(name, 8)
+    def append_byte(self, name, type_converter = None):
+        self.append(name, 8, type_converter)
 
-    def append_word(self, name):
-        self.append(name, 16)
+    def append_word(self, name, type_converter = None):
+        self.append(name, 16, type_converter)
 
-    def append_dword(self, name):
-        self.append(name, 32)
+    def append_dword(self, name, type_converter = None):
+        self.append(name, 32, type_converter)
 
-    def append_qword(self, name):
-        self.append(name, 64)
+    def append_qword(self, name, type_converter = None):
+        self.append(name, 64, type_converter)
 
     def _format_name(self, name, length):
         return str(self._reader.offset() - length).rjust(4, '0') + ": " + name

--- a/integration_tests/emulator/beacon_parser/time_state.py
+++ b/integration_tests/emulator/beacon_parser/time_state.py
@@ -10,5 +10,5 @@ class TimeState(CategoryParser):
         return 64 + 32
 
     def parse(self):
-        self.append_qword("Mission time", lambda x : str(timedelta(milliseconds=x)))
-        self.append_dword("External time", lambda x : str(timedelta(seconds=x)))
+        self.append_qword("Mission time", lambda x: str(timedelta(milliseconds=x)) if x else '')
+        self.append_dword("External time", lambda x: str(timedelta(seconds=x)) if x else '')

--- a/integration_tests/emulator/beacon_parser/time_state.py
+++ b/integration_tests/emulator/beacon_parser/time_state.py
@@ -1,4 +1,5 @@
 from parser import CategoryParser
+from datetime import timedelta
 
 
 class TimeState(CategoryParser):
@@ -9,5 +10,5 @@ class TimeState(CategoryParser):
         return 64 + 32
 
     def parse(self):
-        self.append_qword("Mission time")
-        self.append_dword("External time")
+        self.append_qword("Mission time", lambda x : str(timedelta(milliseconds=x)))
+        self.append_dword("External time", lambda x : str(timedelta(seconds=x)))

--- a/integration_tests/emulator/gui.fbp
+++ b/integration_tests/emulator/gui.fbp
@@ -2423,6 +2423,94 @@
                         <event name="OnUpdateUI"></event>
                     </object>
                 </object>
+                <object class="sizeritem" expanded="1">
+                    <property name="border">5</property>
+                    <property name="flag">wxALL</property>
+                    <property name="proportion">0</property>
+                    <object class="wxCheckBox" expanded="1">
+                        <property name="BottomDockable">1</property>
+                        <property name="LeftDockable">1</property>
+                        <property name="RightDockable">1</property>
+                        <property name="TopDockable">1</property>
+                        <property name="aui_layer"></property>
+                        <property name="aui_name"></property>
+                        <property name="aui_position"></property>
+                        <property name="aui_row"></property>
+                        <property name="best_size"></property>
+                        <property name="bg"></property>
+                        <property name="caption"></property>
+                        <property name="caption_visible">1</property>
+                        <property name="center_pane">0</property>
+                        <property name="checked">0</property>
+                        <property name="close_button">1</property>
+                        <property name="context_help"></property>
+                        <property name="context_menu">1</property>
+                        <property name="default_pane">0</property>
+                        <property name="dock">Dock</property>
+                        <property name="dock_fixed">0</property>
+                        <property name="docking">Left</property>
+                        <property name="enabled">1</property>
+                        <property name="fg"></property>
+                        <property name="floatable">1</property>
+                        <property name="font"></property>
+                        <property name="gripper">0</property>
+                        <property name="hidden">0</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="label">Automatic transmitter simulation</property>
+                        <property name="max_size"></property>
+                        <property name="maximize_button">0</property>
+                        <property name="maximum_size"></property>
+                        <property name="min_size"></property>
+                        <property name="minimize_button">0</property>
+                        <property name="minimum_size"></property>
+                        <property name="moveable">1</property>
+                        <property name="name">is_transmitter_simulated</property>
+                        <property name="pane_border">1</property>
+                        <property name="pane_position"></property>
+                        <property name="pane_size"></property>
+                        <property name="permission">protected</property>
+                        <property name="pin_button">1</property>
+                        <property name="pos"></property>
+                        <property name="resize">Resizable</property>
+                        <property name="show">1</property>
+                        <property name="size"></property>
+                        <property name="style"></property>
+                        <property name="subclass"></property>
+                        <property name="toolbar_pane">0</property>
+                        <property name="tooltip"></property>
+                        <property name="validator_data_type"></property>
+                        <property name="validator_style">wxFILTER_NONE</property>
+                        <property name="validator_type">wxDefaultValidator</property>
+                        <property name="validator_variable"></property>
+                        <property name="window_extra_style"></property>
+                        <property name="window_name"></property>
+                        <property name="window_style"></property>
+                        <event name="OnChar"></event>
+                        <event name="OnCheckBox"></event>
+                        <event name="OnEnterWindow"></event>
+                        <event name="OnEraseBackground"></event>
+                        <event name="OnKeyDown"></event>
+                        <event name="OnKeyUp"></event>
+                        <event name="OnKillFocus"></event>
+                        <event name="OnLeaveWindow"></event>
+                        <event name="OnLeftDClick"></event>
+                        <event name="OnLeftDown"></event>
+                        <event name="OnLeftUp"></event>
+                        <event name="OnMiddleDClick"></event>
+                        <event name="OnMiddleDown"></event>
+                        <event name="OnMiddleUp"></event>
+                        <event name="OnMotion"></event>
+                        <event name="OnMouseEvents"></event>
+                        <event name="OnMouseWheel"></event>
+                        <event name="OnPaint"></event>
+                        <event name="OnRightDClick"></event>
+                        <event name="OnRightDown"></event>
+                        <event name="OnRightUp"></event>
+                        <event name="OnSetFocus"></event>
+                        <event name="OnSize"></event>
+                        <event name="OnUpdateUI"></event>
+                    </object>
+                </object>
             </object>
         </object>
         <object class="Panel" expanded="0">

--- a/integration_tests/emulator/gui.xrc
+++ b/integration_tests/emulator/gui.xrc
@@ -309,6 +309,15 @@
 					<wrap>-1</wrap>
 				</object>
 			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL</flag>
+				<border>5</border>
+				<object class="wxCheckBox" name="is_transmitter_simulated">
+					<label>Automatic transmitter simulation</label>
+					<checked>0</checked>
+				</object>
+			</object>
 		</object>
 	</object>
 	<object class="wxPanel" name="PayloadModule">

--- a/integration_tests/experiment_file/base.py
+++ b/integration_tests/experiment_file/base.py
@@ -19,7 +19,7 @@ def bytes_block(n):
 
 Synchronization = pid(0x47).result('Synchronization')
 
-Timestamp = pid(1) >> packed('<Q').parsecmap(lambda x: timedelta(milliseconds=x))
+Timestamp = pid(1) >> packed('<Q').parsecmap(lambda x: str(timedelta(milliseconds=x)))
 Timestamp >>= label_as('time')
 
 Padding = many1(pid(0xFF)).parsecmap(lambda x: len(x))

--- a/integration_tests/ipython_profile/startup/03-emulator.py
+++ b/integration_tests/ipython_profile/startup/03-emulator.py
@@ -8,10 +8,18 @@ from emulator.last_frames import LastFramesModule
 from emulator.payload import PayloadModule
 from emulator.rtc import RTCModule
 from emulator.comm import CommModule
+from devices.comm import BeaconFrame
+from time import time
 
 last_frames = []
 
-last_beacon = {}
+
+class LastBeacon:
+    def __init__(self):
+        self.time = None
+        self.payload = None
+
+last_beacon = LastBeacon()
 
 def _setup_emulator(system):
     emulator_modules = [
@@ -29,6 +37,9 @@ def _setup_emulator(system):
 
     def store_last_frame(comm, frame):
         decoded = system.frame_decoder.decode(frame)
+        if isinstance(decoded, BeaconFrame):
+            last_beacon.time = time()
+            last_beacon.payload = decoded.payload()
         last_frames.insert(0, decoded)
 
         if len(last_frames) > 90:


### PR DESCRIPTION
- Added transmitter simulator. When it is enabled it gets one by one frame from the queue.
- Mission Time and External time is converted to readable string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/295)
<!-- Reviewable:end -->
