### PR TITLE
Fixed test failures inside Test Experiment Sail Autosend

### DIFF
--- a/integration_tests/devices/comm.py
+++ b/integration_tests/devices/comm.py
@@ -231,8 +231,8 @@ class TransmitterDevice(i2cMock.I2CDevice):
     
     @i2cMock.command([0xAA])
     def _reset(self):
-        call(self.on_reset, None)
-        self.reset()
+        if call(self.on_reset, None) is None:
+            self.reset()
 
     @i2cMock.command([0xAB])
     def _hwreset(self):

--- a/integration_tests/obc/experiments.py
+++ b/integration_tests/obc/experiments.py
@@ -104,7 +104,7 @@ class ExperimentsMixin(OBCMixin):
     def wait_for_experiment_iteration(self, iteration, timeout):
         def condition():
             info = self.experiment_info()
-            return info.IterationCounter == iteration
+            return info.IterationCounter >= iteration
 
         busy_wait(condition, delay=0.1, timeout=timeout)
 

--- a/integration_tests/tests/test_experiment_sail.py
+++ b/integration_tests/tests/test_experiment_sail.py
@@ -50,6 +50,11 @@ class TestExperimentSail(RestartPerTest):
     @clear_state()
     @runlevel(2)
     def test_auto_send(self):
+        def suppress_comm_soft_reset():
+            return False
+
+        self.system.transmitter.on_reset = suppress_comm_soft_reset
+
         self.startup()
         self.system.obc.jump_to_time(timedelta(hours=41))
 
@@ -61,7 +66,7 @@ class TestExperimentSail(RestartPerTest):
         self.assertEqual(frame.correlation_id, 10)
 
         self.system.obc.wait_for_experiment_started(ExperimentType.Sail, 60)
-        self.system.obc.wait_for_experiment_iteration(23, 5 * 20)
+        self.system.obc.wait_for_experiment_iteration(25, 5 * 20)
 
         frame = self.system.comm.get_frame(20)
         self.assertIsInstance(frame, SailExperimentFrame)


### PR DESCRIPTION
Fixed test failures caused by:
- wait_for_experiment_iteration skipping target iterations.
- COMM stall detection removing queued messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/303)
<!-- Reviewable:end -->
