### PR TITLE
OBC FM pinout fix (PD7 and PD5 in datasheet ver. 0.9 are swapped)

### DIFF
--- a/platforms/mcu/FlightModel/Include/mcu/io_map.h
+++ b/platforms/mcu/FlightModel/Include/mcu/io_map.h
@@ -22,11 +22,11 @@ namespace io_map
     using SystickIndicator = PinLocation<gpioPortD, 1>;
     using BootIndicator = PinLocation<gpioPortD, 2>;
 
-    using SailDeployed = PinLocation<gpioPortD, 5>;
+    using SailDeployed = PinLocation<gpioPortD, 7>;
 
     using CamSelect = PiggyBack22;
 
-    using SunSInterrupt = PinLocation<gpioPortD, 7>;
+    using SunSInterrupt = PinLocation<gpioPortD, 5>;
 
     struct Gpio
     {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/314)
<!-- Reviewable:end -->
