### PR TITLE
Add possibility to permanently disable imtq built in detumbling

### DIFF
--- a/integration_tests/devices/__init__.py
+++ b/integration_tests/devices/__init__.py
@@ -9,6 +9,7 @@ from rtc import RTCDevice
 from payload import Payload
 from gpio import GPIODriver
 from camera import *
+from adcs import *
 
 __all__ = [
     'EPS',
@@ -34,5 +35,6 @@ __all__ = [
     "GPIODriver",
     "CameraDriver",
     'CameraLocation',
-    'PhotoResolution'
+    'PhotoResolution',
+    'AdcsMode'
 ]

--- a/integration_tests/devices/adcs.py
+++ b/integration_tests/devices/adcs.py
@@ -1,0 +1,8 @@
+from enum import IntEnum, unique
+
+@unique
+class AdcsMode(IntEnum):
+    Disabled = -1
+    BuiltinDetumbling = 0
+    ExperimentalDetumbling = 1
+    ExperimentalSunpointing = 2

--- a/integration_tests/obc/adcs.py
+++ b/integration_tests/obc/adcs.py
@@ -1,7 +1,12 @@
-from obc_mixin import OBCMixin, command
-
+from obc_mixin import OBCMixin, command, decode_return
+from devices import AdcsMode
 
 class ADCSMixin(OBCMixin):
+
+    def _parse_adcs_mode(result):
+        return AdcsMode(int(result.split(': ')[1]))
+
+    @decode_return(_parse_adcs_mode)
     @command("adcs current")
     def adcs_current(self):
         pass

--- a/integration_tests/obc/state.py
+++ b/integration_tests/obc/state.py
@@ -16,6 +16,10 @@ class StateMixin(OBCMixin):
     def state_get_time_config(self):
         pass
 
+    @command("state get adcs")
+    def state_get_adcs_config(self):
+        pass
+
     @command("state set antenna {0}")
     def state_set_antenna(self, deployment_disabled):
         pass
@@ -26,4 +30,8 @@ class StateMixin(OBCMixin):
 
     @command("state set time_config {0} {1}")
     def state_set_time_config(self, internal_factor, external_factor):
+        pass
+
+    @command("state set adcs {0}")
+    def state_set_adcs_config(self, detumbling_disabled):
         pass

--- a/integration_tests/persistent_state/__init__.py
+++ b/integration_tests/persistent_state/__init__.py
@@ -1,5 +1,6 @@
 from parsec import joint, count
 
+from adcs import *
 from antenna import *
 from boot import *
 from error_counters import *
@@ -14,6 +15,7 @@ PersistentStateParser = joint(
     BootState, 
     SailState,
     ErrorCounters,
+    AdcsConfiguration,
     Message
     )
 

--- a/integration_tests/persistent_state/adcs.py
+++ b/integration_tests/persistent_state/adcs.py
@@ -1,0 +1,5 @@
+from parsec import joint
+from parsing import *
+
+AdcsConfiguration = field('Built In Detumbling Disabled', boolean)
+AdcsConfiguration >>= label_as('Adcs Configuration')

--- a/integration_tests/response_frames/__init__.py
+++ b/integration_tests/response_frames/__init__.py
@@ -16,6 +16,7 @@ import suns
 import disable_overheat_submode
 import sail_experiment
 import set_bitrate
+import adcs
 
 frame_types = []
 frame_types += map(lambda t: t[1], inspect.getmembers(pong, predicate=inspect.isclass))
@@ -30,6 +31,7 @@ frame_types += map(lambda t: t[1], inspect.getmembers(disable_overheat_submode, 
 frame_types += map(lambda t: t[1], inspect.getmembers(suns, predicate=inspect.isclass))
 frame_types += map(lambda t: t[1], inspect.getmembers(sail_experiment, predicate=inspect.isclass))
 frame_types += map(lambda t: t[1], inspect.getmembers(set_bitrate, predicate=inspect.isclass))
+frame_types += map(lambda t: t[1], inspect.getmembers(adcs, predicate=inspect.isclass))
 frame_types = filter(lambda t: issubclass(t, ResponseFrame) and t != ResponseFrame, frame_types)
 frame_types = reduce(lambda t, x: t + [x] if x not in t else t, frame_types, [])
 
@@ -44,5 +46,9 @@ __all__ = [
     'MultipleMatchingFrameTypes',
     'NoMatchingFrameType',
     'CompileInfoFrame',
+    'SetInternalDetumblingModeSuccessFrame',
+    'SetInternalDetumblingModeErrorFrame',
+    'SetAdcsModeSuccessFrame',
+    'SetAdcsModeErrorFrame',
     'frame_factories'
 ]

--- a/integration_tests/response_frames/adcs.py
+++ b/integration_tests/response_frames/adcs.py
@@ -1,0 +1,18 @@
+from response_frames import ResponseFrame, response_frame
+from response_frames.operation import OperationSuccessFrame, OperationErrorFrame
+
+@response_frame(0x1E)
+class SetInternalDetumblingModeSuccessFrame(OperationSuccessFrame):
+    pass
+
+@response_frame(0x1E)
+class SetInternalDetumblingModeErrorFrame(OperationErrorFrame):
+    pass
+
+@response_frame(0x1F)
+class SetAdcsModeSuccessFrame(OperationSuccessFrame):
+    pass
+
+@response_frame(0x1F)
+class SetAdcsModeErrorFrame(OperationErrorFrame):
+    pass

--- a/integration_tests/telecommand/__init__.py
+++ b/integration_tests/telecommand/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     'RemoveFile',
     'PerformDetumblingExperiment',
     'SetTimeCorrectionConfig',
+    'SetTime',
     'EraseBootTableEntry',
     'WriteProgramPart',
     'FinalizeProgramEntry',
@@ -48,6 +49,13 @@ __all__ = [
     'DisableOverheatSubmode',
     'CopyBootSlots',
     'SetBuiltinDetumblingBlockMaskTelecommand',
-    'SetAdcsModeTelecommand'
+    'SetAdcsModeTelecommand',
+    'ResetTransmitterTelecommand',
+    'SetBitrate',
+    'AbortExperiment',
+    'PerformSunSExperiment',
+    'PerformRadFETExperiment',
+    'PerformPayloadCommissioningExperiment',
+    'PerformCameraCommissioningExperiment'
 ]
 

--- a/integration_tests/telecommand/__init__.py
+++ b/integration_tests/telecommand/__init__.py
@@ -15,6 +15,7 @@ from photo import *
 from state import *
 from compile_info import *
 from eps import *
+from adcs import *
 
 __all__ = [
     'DownloadFile',
@@ -45,6 +46,8 @@ __all__ = [
     'PerformSADSExperiment',
     'GetCompileInfoTelecommand',
     'DisableOverheatSubmode',
-    'CopyBootSlots'
+    'CopyBootSlots',
+    'SetBuiltinDetumblingBlockMaskTelecommand',
+    'SetAdcsModeTelecommand'
 ]
 

--- a/integration_tests/telecommand/adcs.py
+++ b/integration_tests/telecommand/adcs.py
@@ -1,0 +1,26 @@
+from telecommand import Telecommand
+from devices.adcs import AdcsMode
+
+class SetBuiltinDetumblingBlockMaskTelecommand(Telecommand):
+    def __init__(self, corelation_id, mask):
+        Telecommand.__init__(self)
+        self._mask = mask
+        self._corelation_id = corelation_id
+
+    def apid(self):
+        return 0x24
+
+    def payload(self):
+        return [self._corelation_id, self._mask]
+
+class SetAdcsModeTelecommand(Telecommand):
+    def __init__(self, corelation_id, mode):
+        Telecommand.__init__(self)
+        self._mode = mode
+        self._corelation_id = corelation_id
+
+    def apid(self):
+        return 0x25
+
+    def payload(self):
+        return [self._corelation_id, self._mode]

--- a/integration_tests/tests/base.py
+++ b/integration_tests/tests/base.py
@@ -4,11 +4,13 @@ import unittest
 import extensions
 from build_config import config
 from system import System
+from tests import _setup_log
 
 class BaseTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(BaseTest, self).__init__(*args, **kwargs)
         self.auto_power_on = True
+        _setup_log()
 
     def power_on_obc(self):
         self.system.restart(self.__class__._get_class_boot_wrappers() + self._get_boot_wrappers(self._testMethodName))

--- a/integration_tests/tests/base.py
+++ b/integration_tests/tests/base.py
@@ -4,13 +4,12 @@ import unittest
 import extensions
 from build_config import config
 from system import System
-from tests import _setup_log
+
 
 class BaseTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(BaseTest, self).__init__(*args, **kwargs)
         self.auto_power_on = True
-        _setup_log()
 
     def power_on_obc(self):
         self.system.restart(self.__class__._get_class_boot_wrappers() + self._get_boot_wrappers(self._testMethodName))

--- a/integration_tests/tests/test_persistent_state.py
+++ b/integration_tests/tests/test_persistent_state.py
@@ -5,16 +5,17 @@ import struct
 class PersistentStateTest(TestCase):
 
     def test_parsing_empty_buffer(self):
-        buffer = "\0" * 276
+        buffer = "\0" * 277
         result = PersistentStateParser.parse_partial(buffer)
 
         self.assertNotEqual(result, None)
-        self.assertEqual(len(result[0]), 7)
+        self.assertEqual(len(result[0]), 8)
         self.assertTrue(result[0][0].has_key('Antenna Configuration'))
         self.assertTrue(result[0][1].has_key('Mission Time'))
         self.assertTrue(result[0][2].has_key('Time Correction'))
         self.assertTrue(result[0][3].has_key('Boot State'))
         self.assertTrue(result[0][4].has_key('Sail State'))
         self.assertTrue(result[0][5].has_key('Error Counters'))
-        self.assertTrue(result[0][6].has_key('Periodic Message'))
+        self.assertTrue(result[0][6].has_key('Adcs Configuration'))
+        self.assertTrue(result[0][7].has_key('Periodic Message'))
         self.assertEqual(len(result[1]), 0)

--- a/integration_tests/tests/test_telecommands_adcs.py
+++ b/integration_tests/tests/test_telecommands_adcs.py
@@ -1,0 +1,39 @@
+from response_frames.adcs import *
+from system import auto_power_on
+from telecommand import SetBuiltinDetumblingBlockMaskTelecommand, SetAdcsModeTelecommand, AdcsMode
+from tests.base import RestartPerTest
+from utils import TestEvent
+
+class TestAdcsTelecommands(RestartPerTest):
+    @auto_power_on(auto_power_on=True)
+    def __init__(self, *args, **kwargs):
+        super(TestAdcsTelecommands, self).__init__(*args, **kwargs)
+
+    def test_set_adcs_mode_success(self):
+
+        self.system.comm.put_frame(SetAdcsModeTelecommand(10, AdcsMode.ExperimentalSunpointing))
+
+        response = self.system.comm.get_frame(5)
+        self.assertIsInstance(response, SetAdcsModeSuccessFrame)
+        self.assertEqual(response.seq(), 0)
+        self.assertEqual(response.correlation_id, 10)
+        self.assertEqual(self.system.obc.adcs_current(), AdcsMode.ExperimentalSunpointing)
+
+    def test_set_adcs_mode_failure(self):
+
+        self.system.comm.put_frame(SetAdcsModeTelecommand(11, 23))
+
+        response = self.system.comm.get_frame(5)
+        self.assertIsInstance(response, SetAdcsModeErrorFrame)
+        self.assertEqual(response.seq(), 0)
+        self.assertEqual(response.correlation_id, 11)
+
+    def test_set_builtin_detumbling_mask(self):
+
+        self.system.comm.put_frame(SetBuiltinDetumblingBlockMaskTelecommand(10, True))
+
+        response = self.system.comm.get_frame(5)
+        self.assertIsInstance(response, SetInternalDetumblingModeSuccessFrame)
+        self.assertEqual(response.seq(), 0)
+        self.assertEqual(response.correlation_id, 10)
+        self.assertEqual(self.system.obc.state_get_adcs_config(), '1\nOK')

--- a/libs/adcs/Include/adcs/AdcsCoordinator.hpp
+++ b/libs/adcs/Include/adcs/AdcsCoordinator.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include "adcs.hpp"
 #include "base/os.h"
@@ -45,6 +46,15 @@ namespace adcs
         virtual OSResult EnableSunPointing() final override;
 
         virtual OSResult Disable() final override;
+
+        virtual void SetBlockMode(AdcsMode adcsMode, bool isBlocked) final override;
+
+        /**
+         * @brief Returns information whether the queried adcs mode is currently blocked.
+         * @param mode Queried mode
+         * @return True when requested mode is blocked, false otherwise.
+         */
+        bool IsModeBlocked(AdcsMode mode) const;
 
       private:
         /**
@@ -103,6 +113,8 @@ namespace adcs
          * @brief Adcs processors.
          */
         std::array<IAdcsProcessor*, 3> adcsProcessors;
+
+        std::array<std::atomic_bool, 3> adcsMasks;
     };
 }
 #endif

--- a/libs/adcs/Include/adcs/adcs.hpp
+++ b/libs/adcs/Include/adcs/adcs.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include "base/os.h"
 
 namespace adcs
@@ -18,7 +19,7 @@ namespace adcs
     /**
      * @brief Enumerator for current adcs operating mode.
      */
-    enum class AdcsMode
+    enum class AdcsMode : std::uint8_t
     {
         /**
          * @brief Adcs is currently disabled.

--- a/libs/adcs/Include/adcs/adcs.hpp
+++ b/libs/adcs/Include/adcs/adcs.hpp
@@ -19,7 +19,7 @@ namespace adcs
     /**
      * @brief Enumerator for current adcs operating mode.
      */
-    enum class AdcsMode : std::uint8_t
+    enum class AdcsMode : std::int8_t
     {
         /**
          * @brief Adcs is currently disabled.

--- a/libs/adcs/Include/adcs/adcs.hpp
+++ b/libs/adcs/Include/adcs/adcs.hpp
@@ -126,6 +126,13 @@ namespace adcs
          * @returns Operation status.
          */
         virtual OSResult Disable() = 0;
+
+        /**
+         * @brief This function can be used to temporarily block one of the ADCS modes.
+         * @param adcsMode Requested mode identifier.
+         * @param isBlocked True when selected mode should be disabled, false otherwise.
+         */
+        virtual void SetBlockMode(AdcsMode adcsMode, bool isBlocked) = 0;
     };
 
     /** @} */

--- a/libs/base/Include/base/os.h
+++ b/libs/base/Include/base/os.h
@@ -39,9 +39,10 @@ enum class OSResult
 {
     /** Success */
     Success = 0,
-
     /** @brief Requested operation is invalid. */
     InvalidOperation = ELAST,
+    /** Power failure */
+    PowerFailure = ELAST + 1,
 
     /** Requested element was not found. */
     NotFound = ENOENT,
@@ -129,9 +130,6 @@ enum class OSResult
     Overflow = EOVERFLOW,
     /** Operation canceled */
     Cancelled = ECANCELED,
-    /** Power failure */
-    PowerFailure = 201
-
 };
 
 /**

--- a/libs/mission/adcs/Include/mission/adcs.hpp
+++ b/libs/mission/adcs/Include/mission/adcs.hpp
@@ -87,6 +87,8 @@ namespace mission
              */
             static void AdcsEnableBuiltinDetumbling(SystemState& state, void* param);
 
+            static bool IsDetumblingDisabled(const SystemState& state);
+
             static constexpr std::uint8_t RetryCount = 3;
 
             /**

--- a/libs/obc/communication/Include/obc/communication.h
+++ b/libs/obc/communication/Include/obc/communication.h
@@ -166,7 +166,7 @@ namespace obc
         obc::telecommands::DisableOverheatSubmodeTelecommand,
         obc::telecommands::SetBitrateTelecommand,
         obc::telecommands::PerformCopyBootSlotsExperiment,
-        obc::telecommands::DisableBuiltinDetumblingTelecommand,
+        obc::telecommands::SetBuiltinDetumblingBlockMaskTelecommand,
         obc::telecommands::SetAdcsModeTelecommand>;
 
     /**

--- a/libs/obc/communication/Include/obc/communication.h
+++ b/libs/obc/communication/Include/obc/communication.h
@@ -4,12 +4,14 @@
 #include <array>
 #include <gsl/span>
 #include <tuple>
+#include "adcs/adcs.hpp"
 #include "comm/CommDriver.hpp"
 #include "i2c/i2c.h"
 #include "mission/comm.hpp"
 #include "mission/time.hpp"
 #include "obc/experiments.hpp"
 #include "obc/fdir.hpp"
+#include "obc/telecommands/adcs.hpp"
 #include "obc/telecommands/antenna.hpp"
 #include "obc/telecommands/boot_settings.hpp"
 #include "obc/telecommands/comm.hpp"
@@ -163,7 +165,9 @@ namespace obc
         obc::telecommands::ResetTransmitterTelecommand,
         obc::telecommands::DisableOverheatSubmodeTelecommand,
         obc::telecommands::SetBitrateTelecommand,
-        obc::telecommands::PerformCopyBootSlotsExperiment>;
+        obc::telecommands::PerformCopyBootSlotsExperiment,
+        obc::telecommands::DisableBuiltinDetumblingTelecommand,
+        obc::telecommands::SetAdcsModeTelecommand>;
 
     /**
      * @brief OBC <-> Earth communication
@@ -194,6 +198,7 @@ namespace obc
          * @param[in] gyro Gyroscope interface
          * @param[in] photo Reference to service capable of taking photos
          * @param[in] epsDriver Reference to EPS driver object
+         * @param[in] adcsCoordinator Reference to Adcs subsystem controller
          */
         OBCCommunication(obc::FDIR& fdir,
             devices::comm::CommObject& commDriver,
@@ -216,7 +221,8 @@ namespace obc
             devices::payload::IPayloadDeviceDriver& payloadDriver,
             devices::gyro::IGyroscopeDriver& gyro,
             services::photo::IPhotoService& photo,
-            devices::eps::IEPSDriver& epsDriver);
+            devices::eps::IEPSDriver& epsDriver,
+            adcs::IAdcsCoordinator& adcsCoordinator);
 
         /**
          * @brief Initializes all communication at runlevel 1

--- a/libs/obc/communication/communication.cpp
+++ b/libs/obc/communication/communication.cpp
@@ -82,7 +82,7 @@ OBCCommunication::OBCCommunication(obc::FDIR& fdir,
           SetBitrateTelecommand(),                                                                                      //
           PerformCopyBootSlotsExperiment(
               experiments.ExperimentsController, experiments.Get<experiment::program::CopyBootSlotsExperiment>()), //
-          DisableBuiltinDetumblingTelecommand(stateContainer, adcsCoordinator),                                    //
+          SetBuiltinDetumblingBlockMaskTelecommand(stateContainer, adcsCoordinator),                               //
           SetAdcsModeTelecommand(adcsCoordinator)                                                                  //
           ),                                                                                                       //
       TelecommandHandler(UplinkProtocolDecoder, SupportedTelecommands.Get())

--- a/libs/obc/communication/communication.cpp
+++ b/libs/obc/communication/communication.cpp
@@ -33,7 +33,8 @@ OBCCommunication::OBCCommunication(obc::FDIR& fdir,
     devices::payload::IPayloadDeviceDriver& payloadDriver,
     devices::gyro::IGyroscopeDriver& gyro,
     services::photo::IPhotoService& photo,
-    devices::eps::IEPSDriver& epsDriver)
+    devices::eps::IEPSDriver& epsDriver,
+    adcs::IAdcsCoordinator& adcsCoordinator)
     : Comm(commDriver),                                                                                                               //
       UplinkProtocolDecoder(settings::CommSecurityCode),                                                                              //
       SupportedTelecommands(                                                                                                          //
@@ -80,8 +81,10 @@ OBCCommunication::OBCCommunication(obc::FDIR& fdir,
           DisableOverheatSubmodeTelecommand(epsDriver),                                                                 //
           SetBitrateTelecommand(),                                                                                      //
           PerformCopyBootSlotsExperiment(
-              experiments.ExperimentsController, experiments.Get<experiment::program::CopyBootSlotsExperiment>()) //
-          ),                                                                                                      //
+              experiments.ExperimentsController, experiments.Get<experiment::program::CopyBootSlotsExperiment>()), //
+          DisableBuiltinDetumblingTelecommand(stateContainer, adcsCoordinator),                                    //
+          SetAdcsModeTelecommand(adcsCoordinator)                                                                  //
+          ),                                                                                                       //
       TelecommandHandler(UplinkProtocolDecoder, SupportedTelecommands.Get())
 {
 }

--- a/libs/obc/communication/telecommands/CMakeLists.txt
+++ b/libs/obc/communication/telecommands/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     state.cpp
     compile_info.cpp
     eps.cpp
+    adcs.cpp
 )
 
 add_library(${NAME} STATIC ${SOURCES})

--- a/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
+++ b/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
@@ -22,7 +22,7 @@ namespace obc
          * Parameters:
          *  - 1-byte - new built-in detumbling mask value, true for disabled, false for enabled
          */
-        class DisableBuiltinDetumblingTelecommand : public telecommunication::uplink::Telecommand<0x24>
+        class SetBuiltinDetumblingBlockMaskTelecommand : public telecommunication::uplink::Telecommand<0x24>
         {
           public:
             /**
@@ -30,7 +30,7 @@ namespace obc
              * @param stateContainer_ Reference to current obc state container
              * @param adcsCoordinator_ Reference to adcs subsystem controller
              */
-            DisableBuiltinDetumblingTelecommand(IHasState<SystemState>& stateContainer_, adcs::IAdcsCoordinator& adcsCoordinator_);
+            SetBuiltinDetumblingBlockMaskTelecommand(IHasState<SystemState>& stateContainer_, adcs::IAdcsCoordinator& adcsCoordinator_);
 
             virtual void Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters) override;
 

--- a/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
+++ b/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
@@ -20,6 +20,7 @@ namespace obc
          *
          * Code: 0x24
          * Parameters:
+         *  - 8-bit - APID that will be used in response
          *  - 1-byte - new built-in detumbling mask value, true for disabled, false for enabled
          */
         class SetBuiltinDetumblingBlockMaskTelecommand : public telecommunication::uplink::Telecommand<0x24>
@@ -44,7 +45,8 @@ namespace obc
          * @telecommand
          *
          * Code: 0x25
-         * Parameters:
+         * Parameters
+         *  - 8-bit - APID that will be used in response:
          *  - 1-byte - new adcs subsystem mode
          */
         class SetAdcsModeTelecommand : public telecommunication::uplink::Telecommand<0x25>

--- a/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
+++ b/libs/obc/communication/telecommands/Include/obc/telecommands/adcs.hpp
@@ -1,0 +1,69 @@
+#ifndef LIBS_OBC_COMMUNICATION_TELECOMMANDS_INCLUDE_OBC_TELECOMMANDS_ADCS_HPP_
+#define LIBS_OBC_COMMUNICATION_TELECOMMANDS_INCLUDE_OBC_TELECOMMANDS_ADCS_HPP_
+
+#pragma once
+
+#include "adcs/adcs.hpp"
+#include "base/IHasState.hpp"
+#include "base/fwd.hpp"
+#include "mission/antenna_task.hpp"
+#include "state/fwd.hpp"
+#include "telecommunication/telecommand_handling.h"
+
+namespace obc
+{
+    namespace telecommands
+    {
+        /**
+         * @brief Disable imtq built in detumbling
+         * @telecommand
+         *
+         * Code: 0x24
+         * Parameters:
+         *  - 1-byte - new built-in detumbling mask value, true for disabled, false for enabled
+         */
+        class DisableBuiltinDetumblingTelecommand : public telecommunication::uplink::Telecommand<0x24>
+        {
+          public:
+            /**
+             * @brief ctor.
+             * @param stateContainer_ Reference to current obc state container
+             * @param adcsCoordinator_ Reference to adcs subsystem controller
+             */
+            DisableBuiltinDetumblingTelecommand(IHasState<SystemState>& stateContainer_, adcs::IAdcsCoordinator& adcsCoordinator_);
+
+            virtual void Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters) override;
+
+          private:
+            IHasState<SystemState>& stateContainer;
+            adcs::IAdcsCoordinator& adcsCoordinator;
+        };
+
+        /**
+         * @brief Set new Adcs subystem operating mode.
+         * @telecommand
+         *
+         * Code: 0x25
+         * Parameters:
+         *  - 1-byte - new adcs subsystem mode
+         */
+        class SetAdcsModeTelecommand : public telecommunication::uplink::Telecommand<0x25>
+        {
+          public:
+            /**
+             * @brief ctor.
+             * @param adcsCoordinator_ Reference to adcs subsystem controller
+             */
+            SetAdcsModeTelecommand(adcs::IAdcsCoordinator& adcsCoordinator_);
+
+            virtual void Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters) override;
+
+          private:
+            void Finish(OSResult result, Writer& writer);
+
+            adcs::IAdcsCoordinator& adcsCoordinator;
+        };
+    }
+}
+
+#endif /* LIBS_OBC_COMMUNICATION_TELECOMMANDS_INCLUDE_OBC_TELECOMMANDS_ADCS_HPP_ */

--- a/libs/obc/communication/telecommands/adcs.cpp
+++ b/libs/obc/communication/telecommands/adcs.cpp
@@ -1,0 +1,95 @@
+#include "adcs.hpp"
+#include "base/reader.h"
+#include "comm/ITransmitter.hpp"
+#include "state/struct.h"
+#include "telecommunication/downlink.h"
+
+using telecommunication::downlink::DownlinkAPID;
+using telecommunication::downlink::DownlinkFrame;
+
+namespace obc
+{
+    namespace telecommands
+    {
+        DisableBuiltinDetumblingTelecommand::DisableBuiltinDetumblingTelecommand(IHasState<SystemState>& stateContainer_, //
+            adcs::IAdcsCoordinator& adcsCoordinator_)
+            : stateContainer(stateContainer_), //
+              adcsCoordinator(adcsCoordinator_)
+        {
+        }
+
+        void DisableBuiltinDetumblingTelecommand::Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters)
+        {
+            DownlinkFrame response(DownlinkAPID::DisableBuiltinDetumbling, 0);
+            auto& writer = response.PayloadWriter();
+            auto& state = this->stateContainer.GetState().PersistentState;
+
+            Reader r(parameters);
+            auto newState = r.ReadByte() != 0;
+            if (!r.Status())
+            {
+                writer.WriteByte(-1);
+            }
+            else if (!state.Set(state::AdcsState(newState)))
+            {
+                writer.WriteByte(-2);
+            }
+            else
+            {
+                this->adcsCoordinator.SetBlockMode(adcs::AdcsMode::BuiltinDetumbling, newState);
+                writer.WriteByte(0);
+            }
+
+            transmitter.SendFrame(response.Frame());
+        }
+
+        SetAdcsModeTelecommand::SetAdcsModeTelecommand(adcs::IAdcsCoordinator& adcsCoordinator_) : adcsCoordinator(adcsCoordinator_)
+        {
+        }
+
+        void SetAdcsModeTelecommand::Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters)
+        {
+            DownlinkFrame response(DownlinkAPID::SetAdcsMode, 0);
+            auto& writer = response.PayloadWriter();
+
+            Reader r(parameters);
+            auto newState = static_cast<adcs::AdcsMode>(r.ReadByte());
+            if (!r.Status())
+            {
+                Finish(OSResult::BufferNotAvailable, writer);
+            }
+            else
+            {
+                switch (newState)
+                {
+                    case adcs::AdcsMode::BuiltinDetumbling:
+                        Finish(this->adcsCoordinator.EnableBuiltinDetumbling(), writer);
+                        break;
+
+                    case adcs::AdcsMode::ExperimentalDetumbling:
+                        Finish(this->adcsCoordinator.EnableExperimentalDetumbling(), writer);
+                        break;
+
+                    case adcs::AdcsMode::ExperimentalSunpointing:
+                        Finish(this->adcsCoordinator.EnableSunPointing(), writer);
+                        break;
+
+                    case adcs::AdcsMode::Disabled:
+                        Finish(this->adcsCoordinator.Disable(), writer);
+                        break;
+
+                    default:
+                        Finish(OSResult::InvalidArgument, writer);
+                        break;
+                }
+            }
+
+            transmitter.SendFrame(response.Frame());
+        }
+
+        void SetAdcsModeTelecommand::Finish(OSResult result, Writer& writer)
+        {
+            writer.WriteDoubleWordLE(num(result));
+        }
+    }
+}

--- a/libs/obc/communication/telecommands/adcs.cpp
+++ b/libs/obc/communication/telecommands/adcs.cpp
@@ -11,14 +11,15 @@ namespace obc
 {
     namespace telecommands
     {
-        DisableBuiltinDetumblingTelecommand::DisableBuiltinDetumblingTelecommand(IHasState<SystemState>& stateContainer_, //
+        SetBuiltinDetumblingBlockMaskTelecommand::SetBuiltinDetumblingBlockMaskTelecommand(IHasState<SystemState>& stateContainer_, //
             adcs::IAdcsCoordinator& adcsCoordinator_)
             : stateContainer(stateContainer_), //
               adcsCoordinator(adcsCoordinator_)
         {
         }
 
-        void DisableBuiltinDetumblingTelecommand::Handle(devices::comm::ITransmitter& transmitter, gsl::span<const std::uint8_t> parameters)
+        void SetBuiltinDetumblingBlockMaskTelecommand::Handle(devices::comm::ITransmitter& transmitter, //
+            gsl::span<const std::uint8_t> parameters)
         {
             DownlinkFrame response(DownlinkAPID::DisableBuiltinDetumbling, 0);
             auto& writer = response.PayloadWriter();

--- a/libs/state/CMakeLists.txt
+++ b/libs/state/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     sail.cpp
     ErrorCountersState.cpp
     comm.cpp
+    adcs.cpp
 )
 
 add_library(${NAME} STATIC ${SOURCES})

--- a/libs/state/Include/state/adcs/AdcsState.hpp
+++ b/libs/state/Include/state/adcs/AdcsState.hpp
@@ -1,0 +1,68 @@
+#ifndef LIBS_STATE_INCLUDE_STATE_ADCS_ADCSSTATE_HPP_
+#define LIBS_STATE_INCLUDE_STATE_ADCS_ADCSSTATE_HPP_
+
+#pragma once
+
+#include <cstdint>
+#include "base/fwd.hpp"
+
+namespace state
+{
+    /**
+     * @brief This type represents persistent state of adcs subsystem.
+     * @persistent_state
+     */
+    class AdcsState final
+    {
+      public:
+        /**
+         * @brief ctor.
+         */
+        AdcsState();
+
+        /**
+         * @brief ctor.
+         * @param[in] value New value of the internal detumbling state.
+         */
+        AdcsState(bool isInternalDetumblingDisabled);
+
+        /**
+         * @brief Returns flag indicating whether the internal detumbling is disabled.
+         * @return True if the internal detumbling is disabled, false otherwise.
+         */
+        bool IsInternalDetumblingDisabled() const noexcept;
+
+        /**
+         * @brief Read the adcs state from passed reader.
+         * @param[in] reader Buffer reader that should be used to read the serialized state.
+         */
+        void Read(Reader& reader);
+
+        /**
+         * @brief Write the adcs state to passed buffer writer object.
+         * @param[in] writer Buffer writer object that should be used to write the serialized state.
+         */
+        void Write(Writer& writer) const;
+
+        /**
+         * @brief Returns size of the serialized state in bytes.
+         * @return Size of the serialized state in bytes.
+         */
+        static constexpr std::uint32_t Size();
+
+      private:
+        bool internalDetumblingDisabled;
+    };
+
+    inline bool AdcsState::IsInternalDetumblingDisabled() const noexcept
+    {
+        return this->internalDetumblingDisabled;
+    }
+
+    constexpr std::uint32_t AdcsState::Size()
+    {
+        return 1;
+    }
+}
+
+#endif /* LIBS_STATE_INCLUDE_STATE_ADCS_ADCSSTATE_HPP_ */

--- a/libs/state/Include/state/adcs/AdcsState.hpp
+++ b/libs/state/Include/state/adcs/AdcsState.hpp
@@ -22,7 +22,7 @@ namespace state
 
         /**
          * @brief ctor.
-         * @param[in] value New value of the internal detumbling state.
+         * @param[in] isInternalDetumblingDisabled New value of the internal detumbling mask.
          */
         AdcsState(bool isInternalDetumblingDisabled);
 

--- a/libs/state/Include/state/fwd.hpp
+++ b/libs/state/Include/state/fwd.hpp
@@ -13,6 +13,7 @@ namespace state
     class SailState;
     class ErrorCountersConfigState;
     class MessageState;
+    class AdcsState;
 
     struct NoTrackingStatePolicy;
     class StateTrackingPolicy;
@@ -25,6 +26,7 @@ namespace state
         BootState,                                       //
         SailState,                                       //
         ErrorCountersConfigState,                        //
+        AdcsState,                                       //
         MessageState                                     //
         >
         SystemPersistentState;

--- a/libs/state/Include/state/struct.h
+++ b/libs/state/Include/state/struct.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include "LockablePersistentState.hpp"
 #include "StatePolicies.hpp"
+#include "adcs/AdcsState.hpp"
 #include "adcs/adcs.hpp"
 #include "antenna/AntennaConfiguration.hpp"
 #include "antenna/AntennaState.hpp"

--- a/libs/state/adcs.cpp
+++ b/libs/state/adcs.cpp
@@ -1,0 +1,24 @@
+#include "adcs/AdcsState.hpp"
+#include "base/reader.h"
+#include "base/writer.h"
+
+namespace state
+{
+    AdcsState::AdcsState() : internalDetumblingDisabled(false)
+    {
+    }
+
+    AdcsState::AdcsState(bool isInternalDetumblingDisabled) : internalDetumblingDisabled(isInternalDetumblingDisabled)
+    {
+    }
+
+    void AdcsState::Read(Reader& reader)
+    {
+        this->internalDetumblingDisabled = reader.ReadByte() != 0;
+    }
+
+    void AdcsState::Write(Writer& writer) const
+    {
+        writer.WriteByte(this->internalDetumblingDisabled);
+    }
+}

--- a/libs/telecommunication/include/telecommunication/downlink.h
+++ b/libs/telecommunication/include/telecommunication/downlink.h
@@ -57,7 +57,7 @@ namespace telecommunication
             PeriodicSet = 0x1B,                //!< Set periodic message
             SailExperiment = 0x1C,             //!< Automatically sent sail experiment data
             CopyBootTable = 0x1D,              //!< Automatically sent during copy boot slots experiment
-            DisableBuiltinDetumbling = 0x1E,   //!< Disabling imtq built-in detumbling command
+            SetInternalDetumblingMode = 0x1E,  //!< Disabling imtq built-in detumbling command
             SetAdcsMode = 0x1F,                //!< Set Adcs Mode telecommand
             Telemetry = 0x3F,                  //!< TelemetryLong
             LastItem                           //!< LastItem

--- a/libs/telecommunication/include/telecommunication/downlink.h
+++ b/libs/telecommunication/include/telecommunication/downlink.h
@@ -57,6 +57,8 @@ namespace telecommunication
             PeriodicSet = 0x1B,                //!< Set periodic message
             SailExperiment = 0x1C,             //!< Automatically sent sail experiment data
             CopyBootTable = 0x1D,              //!< Automatically sent during copy boot slots experiment
+            DisableBuiltinDetumbling = 0x1E,   //!< Disabling imtq built-in detumbling command
+            SetAdcsMode = 0x1F,                //!< Set Adcs Mode telecommand
             Telemetry = 0x3F,                  //!< TelemetryLong
             LastItem                           //!< LastItem
         };

--- a/src/obc.cpp
+++ b/src/obc.cpp
@@ -127,7 +127,8 @@ OBC::OBC()
           Hardware.PayloadDeviceDriver,
           Hardware.Gyro,
           Camera.PhotoService,
-          Hardware.EPS),
+          Hardware.EPS,
+          adcs.GetAdcsCoordinator()),
       Scrubbing(this->Hardware, this->BootTable, this->BootSettings, boot::Index),         //
       terminal(this->Hardware.Terminal),                                                   //
       camera(this->Fdir.ErrorCounting(), this->Hardware.Camera),                           //

--- a/src/obc.h
+++ b/src/obc.h
@@ -35,7 +35,7 @@
 #include "time/timer.h"
 #include "utils.h"
 #include "watchdog/pin.hpp"
-
+#include "state/fwd.hpp"
 /**
  * @defgroup obc OBC structure
  *
@@ -80,6 +80,8 @@ struct OBC
      * @return Line IO implementation
      */
     inline ILineIO& GetLineIO();
+
+    void InitializeAdcs(const state::SystemPersistentState& persistentState);
 
     /** @brief File system object */
     services::fs::YaffsFileSystem fs;

--- a/src/obc.h
+++ b/src/obc.h
@@ -31,11 +31,11 @@
 #include "program_flash/boot_table.hpp"
 #include "scrubber/ram.hpp"
 #include "spi/efm.h"
+#include "state/fwd.hpp"
 #include "terminal/terminal.h"
 #include "time/timer.h"
 #include "utils.h"
 #include "watchdog/pin.hpp"
-#include "state/fwd.hpp"
 /**
  * @defgroup obc OBC structure
  *
@@ -81,6 +81,10 @@ struct OBC
      */
     inline ILineIO& GetLineIO();
 
+    /**
+     * @brief Initialize adcs subsystem.
+     * @param persistentState Reference to obc global persistent state.
+     */
     void InitializeAdcs(const state::SystemPersistentState& persistentState);
 
     /** @brief File system object */

--- a/unit_tests/base/Include/mock/AdcsMocks.hpp
+++ b/unit_tests/base/Include/mock/AdcsMocks.hpp
@@ -22,6 +22,8 @@ struct AdcsCoordinatorMock : adcs::IAdcsCoordinator
     MOCK_METHOD0(EnableSunPointing, OSResult());
 
     MOCK_METHOD0(Disable, OSResult());
+
+    MOCK_METHOD2(SetBlockMode, void(adcs::AdcsMode adcsMode, bool isBlocked));
 };
 
 struct DetumblingMock : adcs::IAdcsProcessor

--- a/unit_tests/mission/MissionPlan/adcs/AdcsPrimaryTaskTest.cpp
+++ b/unit_tests/mission/MissionPlan/adcs/AdcsPrimaryTaskTest.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock-matchers.h"
+#include "OsMock.hpp"
 #include "mission/adcs.hpp"
 #include "mock/AdcsMocks.hpp"
 #include "state/struct.h"
@@ -8,12 +9,15 @@ using namespace std::chrono_literals;
 
 using testing::Eq;
 using testing::Return;
+using testing::_;
+
 namespace
 {
     struct AdcsPrimaryTaskTest : public testing::Test
     {
         AdcsPrimaryTaskTest();
 
+        OSMock os;
         SystemState state;
         AdcsCoordinatorMock coordinator;
         mission::adcs::AdcsPrimaryTask task;
@@ -22,27 +26,30 @@ namespace
     };
 
     AdcsPrimaryTaskTest::AdcsPrimaryTaskTest() //
-        : task(coordinator),
-          primaryAction(task.BuildAction()),
-          updateStep(task.BuildUpdate())
+        : task(coordinator), primaryAction(task.BuildAction()), updateStep(task.BuildUpdate())
     {
         this->state.AntennaState.SetDeployment(true);
         this->state.Time = 42min;
+        ON_CALL(os, TakeSemaphore(_, _)).WillByDefault(Return(OSResult::Success));
+        ON_CALL(os, GiveSemaphore(_)).WillByDefault(Return(OSResult::Success));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestInitialState)
     {
+        auto guard = InstallProxy(&os);
         ASSERT_THAT(this->task.IsDisabled(), Eq(false));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestDisablingPrimaryDetumbling)
     {
+        auto guard = InstallProxy(&os);
         this->task.Disable();
         ASSERT_THAT(this->task.IsDisabled(), Eq(true));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestReenablingPrimaryDetumbling)
     {
+        auto guard = InstallProxy(&os);
         this->task.Disable();
         this->task.RunDetumbling();
         ASSERT_THAT(this->task.IsDisabled(), Eq(false));
@@ -50,24 +57,28 @@ namespace
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionSilentPeriod)
     {
+        auto guard = InstallProxy(&os);
         this->state.Time = 25min;
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionActivePeriodAdcsAlreadyActive)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::BuiltinDetumbling));
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionActivePeriodAdcsIsDoingSomethingElse)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::ExperimentalSunpointing));
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionActivePeriodAntennasNotDeployed)
     {
+        auto guard = InstallProxy(&os);
         this->state.AntennaState.SetDeployment(false);
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::Disabled));
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
@@ -75,12 +86,22 @@ namespace
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionSuccess)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::Disabled));
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(true));
     }
 
+    TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingDisabledCondition)
+    {
+        auto guard = InstallProxy(&os);
+        state.PersistentState.Set(state::AdcsState(true));
+        EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::Disabled));
+        ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
+    }
+
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingConditionDisabled)
     {
+        auto guard = InstallProxy(&os);
         this->task.Disable();
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::Disabled));
         ASSERT_THAT(this->primaryAction.condition(this->state, this->primaryAction.param), Eq(false));
@@ -88,12 +109,14 @@ namespace
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingActionSuccess)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, EnableBuiltinDetumbling()).WillOnce(Return(OSResult::Success));
         this->primaryAction.actionProc(this->state, this->primaryAction.param);
     }
 
     TEST_F(AdcsPrimaryTaskTest, TestPrimaryDetumblingRepeatedFailure)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, EnableBuiltinDetumbling()).WillRepeatedly(Return(OSResult::IOError));
         for (int i = 0; i < 5; ++i)
         {
@@ -105,6 +128,7 @@ namespace
 
     TEST_F(AdcsPrimaryTaskTest, TestAdcsUpdateTask)
     {
+        auto guard = InstallProxy(&os);
         EXPECT_CALL(coordinator, CurrentMode()).WillOnce(Return(adcs::AdcsMode::ExperimentalSunpointing));
         this->updateStep.updateProc(this->state, this->updateStep.param);
         ASSERT_THAT(this->state.AdcsMode, Eq(adcs::AdcsMode::ExperimentalSunpointing));


### PR DESCRIPTION
New telecommands: 
* SetBuiltinDetumblingBlockMaskTelecommand: updates builtin detumbling telecommand mask
* SetAdcsModeTelecommand: requests immediate adcs subsystem mode change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/331)
<!-- Reviewable:end -->
