### PR TITLE
Masked antennas error counters

### DIFF
--- a/src/obc.cpp
+++ b/src/obc.cpp
@@ -5,6 +5,7 @@
 #include "mission.h"
 #include "terminal.h"
 #include "watchdog/internal.hpp"
+#include "antenna/driver.h"
 
 static void ProcessState(OBC* obc)
 {
@@ -76,7 +77,9 @@ static std::uint16_t GetErrorCounterMask()
         1 << devices::fm25w::RedundantFM25WDriver::ErrorCounter::DeviceId |      //
         1 << devices::payload::PayloadDriver::ErrorCounter::DeviceId |           //
         1 << devices::camera::LowLevelCameraDriver::ErrorCounter::DeviceId |     //
-        1 << devices::suns::SunSDriver::ErrorCounter::DeviceId;
+        1 << devices::suns::SunSDriver::ErrorCounter::DeviceId |                 //
+        1 << antenna_error_counters::PrimaryChannel::ErrorCounter::DeviceId |    //
+        1 << antenna_error_counters::SecondaryChannel::ErrorCounter::DeviceId;   //
 }
 
 OBC::OBC()


### PR DESCRIPTION
Primary and secondary antenna error counters does not cause power cycle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/338)
<!-- Reviewable:end -->
