### PR TITLE
Remove antennas reset at bootup (they are powered off)

### DIFF
--- a/integration_tests/tests/test_antenna.py
+++ b/integration_tests/tests/test_antenna.py
@@ -10,20 +10,6 @@ class Test_Antenna(RestartPerTest):
     def __init__(self, methodName='runTest'):
         super(Test_Antenna, self).__init__(methodName)
 
-    @runlevel(2)
-    def test_primary_antenna_is_reset_at_startup(self):
-        event = TestEvent()
-        self.system.primary_antenna.on_reset = event.set
-        self.power_on_obc()
-        self.assertTrue(event.wait_for_change(1))
-
-    @runlevel(2)
-    def test_backup_antenna_is_reset_at_startup(self):
-        event = TestEvent()
-        self.system.backup_antenna.on_reset = event.set
-        self.power_on_obc()
-        self.assertTrue(event.wait_for_change(1))
-
     @runlevel(1)
     def test_auto_deployment(self):
         event = TestEvent()

--- a/src/obc.cpp
+++ b/src/obc.cpp
@@ -212,11 +212,6 @@ OSResult OBC::InitializeRunlevel2()
 {
     this->Communication.InitializeRunlevel2();
 
-    if (OS_RESULT_FAILED(this->Hardware.antennaDriver.HardReset()))
-    {
-        LOG(LOG_LEVEL_ERROR, "[obc] Unable to reset both antenna controllers. ");
-    }
-
     Mission.Resume();
 
     TelemetryAcquisition.Resume();


### PR DESCRIPTION
This should fix [NCR#037](https://team.pw-sat.pl/w/ncr/ncr37/).

Antennas are powered off by default, so resetting controllers won't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/349)
<!-- Reviewable:end -->
