### PR TITLE
Added delays for power operations

### DIFF
--- a/libs/experiments/payload/payload_exp.cpp
+++ b/libs/experiments/payload/payload_exp.cpp
@@ -76,6 +76,9 @@ namespace experiment
         {
             ++_currentStep;
 
+            // sleep after turning off LCL before turning it on again
+            System::SleepTask(6s);
+
             switch (_currentStep)
             {
                 default:

--- a/libs/photo/photo_service.cpp
+++ b/libs/photo/photo_service.cpp
@@ -62,6 +62,8 @@ namespace services
                     break;
             }
 
+            System::SleepTask(6s);
+
             return result ? OSResult::Success : OSResult::IOError;
         }
 

--- a/unit_tests/mission/Experiments/payload/PayloadExperimentTest.cpp
+++ b/unit_tests/mission/Experiments/payload/PayloadExperimentTest.cpp
@@ -112,6 +112,7 @@ namespace
     {
         {
             InSequence s;
+            EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(6s)));
             TelemetrySnapshotStepTest();
             EXPECT_CALL(_power, SensPower(true)).WillOnce(Return(true));
             EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(10s)));
@@ -131,6 +132,7 @@ namespace
     {
         {
             InSequence s;
+            EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(6s)));
             TelemetrySnapshotStepTest();
             EXPECT_CALL(_power, SensPower(true)).WillOnce(Return(true));
             EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(2s)));
@@ -160,6 +162,7 @@ namespace
     {
         {
             InSequence s;
+            EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(6s)));
             TelemetrySnapshotStepTest();
             EXPECT_CALL(_power, CameraNadir(true)).WillOnce(Return(true));
             EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(10s)));
@@ -188,6 +191,8 @@ namespace
 
     void PayloadExperimentTest::CamsFullStepTest()
     {
+        EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(6s)));
+
         // InSequence from main test can't (?) be switched off
         for (int i = 0; i < 10; ++i)
         {
@@ -225,6 +230,7 @@ namespace
     {
         {
             InSequence s;
+            EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(6s)));
             TelemetrySnapshotStepTest();
             EXPECT_CALL(_power, SunSPower(true)).WillOnce(Return(true));
             EXPECT_CALL(_os, Sleep(duration_cast<milliseconds>(2s)));


### PR DESCRIPTION
Added:
 * `6 s` delay after turning off the camera in photoservice
 * `6 s` between steps in payload commissioning experiment

This should fix [NCR#041](https://team.pw-sat.pl/w/ncr/ncr41/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/350)
<!-- Reviewable:end -->
