### PR TITLE
Delay after turning on overheat mode

### DIFF
--- a/libs/mission/sail/Include/mission/sail.hpp
+++ b/libs/mission/sail/Include/mission/sail.hpp
@@ -179,7 +179,7 @@ namespace mission
         using StepProc = void (*)(OpenSailTask* This, SystemState& state);
 
         /** @brief Sail opening steps */
-        static StepProc Steps[24];
+        static StepProc Steps[25];
         /** @brief Steps count */
         static constexpr std::uint8_t StepsCount = count_of(Steps);
     };

--- a/libs/mission/sail/sail.cpp
+++ b/libs/mission/sail/sail.cpp
@@ -8,6 +8,7 @@ namespace mission
 {
     OpenSailTask::StepProc OpenSailTask::Steps[] = {
         &IgnoreOverheat,               //
+        &Delay100ms,                   //
                                        //
         &EnableMainThermalKnife,       //
         &Delay100ms,                   //

--- a/unit_tests/mission/MissionPlan/sail/OpenSailTest.cpp
+++ b/unit_tests/mission/MissionPlan/sail/OpenSailTest.cpp
@@ -49,6 +49,7 @@ TEST_F(OpenSailTest, ShouldPerformSailOpeningProcedure)
         InSequence s;
 
         EXPECT_CALL(this->_power, IgnoreOverheat());
+        EXPECT_CALL(this->_os, Sleep(100ms));
 
         EXPECT_CALL(this->_power, MainThermalKnife(true));
         EXPECT_CALL(this->_os, Sleep(100ms));


### PR DESCRIPTION
If `IgnoreOverheat` and `EnableMainThermalKnife` are send simultaneously there is a possiblity of race condition when:
  - overheat was detected, so turning off LCLs
  - in the middle, interrupt is server to disable overheat mode (but on-going check is still going)
  - then, before end, TK is enabled and immediatelly disabled by overheat protection.

This event is very unlikely (there is a window of about 2ms each second, and those two command would have to be send with less than 2ms interval. However fix was simple and should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/361)
<!-- Reviewable:end -->
