### PR TITLE
Wait for COMM bootup

### DIFF
--- a/libs/drivers/comm/Include/comm/CommDriver.hpp
+++ b/libs/drivers/comm/Include/comm/CommDriver.hpp
@@ -57,16 +57,24 @@ class CommObject final : public ITransmitter,      //
     bool Pause();
 
     /**
-     * @brief Restarts the comm driver.
+     * @brief Starts the comm driver.
      *
      * @return Operation status, true in case of success, false otherwise.
      *
-     * During the driver restart process entire hardware is being reseted, and all of the background
-     * tasks are being started.
+     * During the driver all the background tasks are started.
      *
      * Calling this method twice without intermediate call to the CommPause procedure leads to undefined behavior.
      */
-    bool Restart();
+    bool StartTask();
+
+    /**
+     * @brief Restarts the TRxVU COMM board.
+     *
+     * @return Operation status, true in case of success, false otherwise.
+     *
+     * Power-cycles COMM board.
+     */
+    bool RestartHardware();
 
     /**
      * @brief Sets handler that will be called for every received frame

--- a/libs/drivers/comm/comm.cpp
+++ b/libs/drivers/comm/comm.cpp
@@ -187,14 +187,19 @@ OSResult CommObject::Initialize()
     return OSResult::Success;
 }
 
-bool CommObject::Restart()
+bool CommObject::StartTask()
 {
-    ErrorReporter errorContext(_error);
-
     if (this->_pollingTaskFlags.IsSet(TaskFlagRunning))
     {
         return false;
     }
+
+    return this->Resume();
+}
+
+bool CommObject::RestartHardware()
+{
+    ErrorReporter errorContext(_error);
 
     if (!ResetInternal(errorContext.Counter()))
     {
@@ -202,7 +207,7 @@ bool CommObject::Restart()
         return false >> errorContext.Counter();
     }
 
-    return this->Resume();
+    return true;
 }
 
 bool CommObject::Pause()

--- a/libs/obc/communication/communication.cpp
+++ b/libs/obc/communication/communication.cpp
@@ -94,12 +94,16 @@ OBCCommunication::OBCCommunication(obc::FDIR& fdir,
 void OBCCommunication::InitializeRunlevel1()
 {
     this->Comm.SetFrameHandler(this->TelecommandHandler);
+    if (!this->Comm.RestartHardware())
+    {
+        LOG(LOG_LEVEL_ERROR, "Unable to restart COMM hardware");
+    }
 }
 
 void OBCCommunication::InitializeRunlevel2()
 {
-    if (!this->Comm.Restart())
+    if (!this->Comm.StartTask())
     {
-        LOG(LOG_LEVEL_ERROR, "Unable to restart comm");
+        LOG(LOG_LEVEL_ERROR, "Unable to start comm task");
     }
 }

--- a/test/generate_persistent_state/main.cpp
+++ b/test/generate_persistent_state/main.cpp
@@ -1,7 +1,7 @@
 #include <array>
 #include <cstdio>
 #include <unistd.h>
-#include "base/Writer.h"
+#include "base/writer.h"
 #include "state/LockablePersistentState.hpp"
 #include "state/StatePolicies.hpp"
 #include "state/adcs/AdcsState.hpp"

--- a/unit_tests/drivers/Comm/CommTest.cpp
+++ b/unit_tests/drivers/Comm/CommTest.cpp
@@ -1191,32 +1191,31 @@ namespace
         ASSERT_THAT(error_counter, Eq(8));
     }
 
-    TEST_F(CommTest, TestRestartResetFailure)
+    TEST_F(CommTest, TestRestartHardwareFailure)
     {
         i2c.ExpectWriteCommand(ReceiverAddress, HardwareReset).WillOnce(Return(I2CResult::Nack));
-
-        EXPECT_CALL(system, ResumeTask(_)).Times(0);
-
-        ASSERT_THAT(comm.Restart(), Eq(false));
+        ASSERT_THAT(comm.RestartHardware(), Eq(false));
         ASSERT_THAT(error_counter, Eq(5));
     }
 
-    TEST_F(CommTest, TestRestart)
+    TEST_F(CommTest, TestRestartHardware)
+    {
+        i2c.ExpectWriteCommand(ReceiverAddress, HardwareReset).WillOnce(Return(I2CResult::OK));
+        ASSERT_THAT(comm.RestartHardware(), Eq(true));
+        ASSERT_THAT(error_counter, Eq(0));
+    }
+
+    TEST_F(CommTest, TestStartTask)
     {
         EXPECT_CALL(system, ResumeTask(_));
-        i2c.ExpectWriteCommand(ReceiverAddress, HardwareReset).WillOnce(Return(I2CResult::OK));
-        ASSERT_THAT(comm.Restart(), Eq(true));
-        ASSERT_THAT(error_counter, Eq(0));
+        ASSERT_THAT(comm.StartTask(), Eq(true));
     }
 
     TEST_F(CommTest, TestRestartFailIfAlreadyRunning)
     {
         ON_CALL(system, EventGroupGetBits(_)).WillByDefault(Return(4));
         EXPECT_CALL(system, ResumeTask(_)).Times(0);
-        i2c.ExpectWriteCommand(ReceiverAddress, HardwareReset).Times(0);
-        ASSERT_THAT(comm.Restart(), Eq(false));
-
-        ASSERT_THAT(error_counter, Eq(0));
+        ASSERT_THAT(comm.StartTask(), Eq(false));
     }
 
     TEST_F(CommTest, DoNotTriggerTransmitterResetIfQueueIsServedOnTime)


### PR DESCRIPTION
After hardware reset of COMM delay is necessary - hardware reset performs power cycle of COMMs module and it takes some time to initialise.

![2017-10-20-014716_1920x1200_scrot](https://user-images.githubusercontent.com/1294260/31800602-e191b608-b539-11e7-8e00-8c2c22c3f0b0.png)

Moved resetting COMM to `OBCCommunication::InitializeRunlevel1`.

[NCR#13](https://team.pw-sat.pl/w/ncr/ncr13/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/367)
<!-- Reviewable:end -->
