### PR TITLE
Minor telecommand fixes

### DIFF
--- a/integration_tests/devices/suns.py
+++ b/integration_tests/devices/suns.py
@@ -25,7 +25,7 @@ def to_uint16_xyzw(tab):
 class SunS(i2cMock.I2CDevice):
 
     def __init__(self, gpio_driver, pin):
-        super(SunS, self).__init__(0x44, "Imtq")
+        super(SunS, self).__init__(0x44, "Suns")
 
         self.interrupt_pin = pin
         self.gpioDriver = gpio_driver

--- a/integration_tests/telecommand/i2c.py
+++ b/integration_tests/telecommand/i2c.py
@@ -1,11 +1,12 @@
 import struct
 
-from telecommand.base import Telecommand
+from telecommand.base import CorrelatedTelecommand
 from utils import ensure_byte_list
 
 
-class RawI2C(Telecommand):
+class RawI2C(CorrelatedTelecommand):
     def __init__(self, correlation_id, busSelect, address, delay, data):
+        super(RawI2C, self).__init__(correlation_id)
         self._correlation_id = ensure_byte_list(struct.pack('B', correlation_id))
         self._busSelect = ensure_byte_list(struct.pack('B', busSelect))
         self._address = ensure_byte_list(struct.pack('B', address))


### PR DESCRIPTION
Ensure that RawI2C command follows convention regarding the correllation_id

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/398)
<!-- Reviewable:end -->
