### PR TITLE
Allow setting of non-default GRC host/port in zmq device mock adapter

### DIFF
--- a/integration_tests/emulator/comm_zmq_adapter.py
+++ b/integration_tests/emulator/comm_zmq_adapter.py
@@ -8,7 +8,7 @@ from utils import ensure_string
 
 
 class ZeroMQAdapter(object):
-    def __init__(self, comm):
+    def __init__(self, comm, grc_uplink_ip="localhost", grc_uplink_port=7002, grc_downlink_ip="localhost", grc_downlink_port=7003):
         self._comm = comm  # type: devices.Comm
 
         self._comm.transmitter.on_send_frame = self._on_downlink_frame
@@ -23,13 +23,13 @@ class ZeroMQAdapter(object):
         self._downlink_gnuradio_pub = self._context.socket(zmq.PUB)
 
         self._socket_uplink.bind("tcp://*:%s" % 7000)
-        self._socket_uplink_gnuradio.connect("tcp://localhost:%s" % 7002)
+        self._socket_uplink_gnuradio.connect("tcp://{0}:{1}".format(grc_uplink_ip, grc_uplink_port))
 
         self._downlink_new_msg.bind("inproc://downlink/new_msg")
         self._downlink_delay_msg.connect("inproc://downlink/new_msg")
 
         self._downlink_pub.bind("tcp://*:%s" % 7001)
-        self._downlink_gnuradio_pub.connect("tcp://localhost:%s" % 7003)
+        self._downlink_gnuradio_pub.connect("tcp://{0}:{1}".format(grc_downlink_ip, grc_downlink_port))
 
         self._socket_uplink.setsockopt(zmq.SUBSCRIBE, '')
         self._socket_uplink_gnuradio.setsockopt(zmq.SUBSCRIBE, '')

--- a/integration_tests/emulator/comm_zmq_adapter.py
+++ b/integration_tests/emulator/comm_zmq_adapter.py
@@ -8,7 +8,7 @@ from utils import ensure_string
 
 
 class ZeroMQAdapter(object):
-    def __init__(self, comm, grc_uplink_ip="localhost", grc_uplink_port=7002, grc_downlink_ip="localhost", grc_downlink_port=7003):
+    def __init__(self, comm, grc_uplink_address="tcp://localhost:7002", grc_downlink_address="tcp://localhost:7003"):
         self._comm = comm  # type: devices.Comm
 
         self._comm.transmitter.on_send_frame = self._on_downlink_frame
@@ -23,13 +23,13 @@ class ZeroMQAdapter(object):
         self._downlink_gnuradio_pub = self._context.socket(zmq.PUB)
 
         self._socket_uplink.bind("tcp://*:%s" % 7000)
-        self._socket_uplink_gnuradio.connect("tcp://{0}:{1}".format(grc_uplink_ip, grc_uplink_port))
+        self._socket_uplink_gnuradio.connect(grc_uplink_address)
 
         self._downlink_new_msg.bind("inproc://downlink/new_msg")
         self._downlink_delay_msg.connect("inproc://downlink/new_msg")
 
         self._downlink_pub.bind("tcp://*:%s" % 7001)
-        self._downlink_gnuradio_pub.connect("tcp://{0}:{1}".format(grc_downlink_ip, grc_downlink_port))
+        self._downlink_gnuradio_pub.connect(grc_downlink_address)
 
         self._socket_uplink.setsockopt(zmq.SUBSCRIBE, '')
         self._socket_uplink_gnuradio.setsockopt(zmq.SUBSCRIBE, '')

--- a/integration_tests/tools/just_mocks.py
+++ b/integration_tests/tools/just_mocks.py
@@ -94,10 +94,8 @@ Arguments may also be stored in file and passed with '@file' syntax. Arguments i
 
     parser.add_argument('-z', '--disable-zmq', action='store_true', default=False, help="Disable ZeroMQ COMM adapter")
 
-    parser.add_argument('--grc_uplink_ip', required=False, default='localhost', help="GRC Uplink IP")
-    parser.add_argument('--grc_uplink_port', required=False, default=7002, help="GRC Uplink PORT")
-    parser.add_argument('--grc_downlink_ip', required=False, default='localhost', help="GRC Downlink IP")
-    parser.add_argument('--grc_downlink_port', required=False, default=7003, help="GRC Downlink PORT")
+    parser.add_argument('--grc_uplink_address', required=False, default='tcp://localhost:7002', help="GRC Uplink ZMQ address")
+    parser.add_argument('--grc_downlink_address', required=False, default='tcp://localhost:7003', help="GRC Downlink ZMQ address")
 
     device_selection_group = parser.add_mutually_exclusive_group(required=True)
     device_selection_group.add_argument('--except',
@@ -126,7 +124,7 @@ Arguments may also be stored in file and passed with '@file' syntax. Arguments i
 
 
 class JustMocks(object):
-    def __init__(self, mock_com, enable_zmq, grc_uplink_ip="localhost", grc_uplink_port=7002, grc_downlink_ip="localhost", grc_downlink_port=7003):
+    def __init__(self, mock_com, enable_zmq, grc_uplink_address="tcp://localhost:7002", grc_downlink_address="tcp://localhost:7003"):
         self._mock_com = mock_com
 
         self.i2c = I2CMock(mock_com)
@@ -158,7 +156,7 @@ class JustMocks(object):
         self.i2c.add_pld_device(self.gyro)
 
         if enable_zmq:
-            self.zmq_adapter = ZeroMQAdapter(self.comm, grc_uplink_ip=grc_uplink_ip, grc_uplink_port=grc_uplink_port, grc_downlink_ip=grc_downlink_ip, grc_downlink_port=grc_downlink_port)
+            self.zmq_adapter = ZeroMQAdapter(self.comm, grc_uplink_address=grc_uplink_address, grc_downlink_address=grc_downlink_address)
 
     def start(self, devices_to_enable):
         self.i2c.start(enable_devices=False)
@@ -195,8 +193,7 @@ config = imp.load_source('config', args.config)
 
 devices_to_enable = {k: AVAILABLE_DEVICES[k] for k in args.enabled_devices}
 
-just_mocks = JustMocks(mock_com=config.config['MOCK_COM'], enable_zmq=not args.disable_zmq,
-					  grc_uplink_ip=args.grc_uplink_ip, grc_uplink_port=args.grc_uplink_port, grc_downlink_ip=args.grc_downlink_ip, grc_downlink_port=args.grc_downlink_port)
+just_mocks = JustMocks(mock_com=config.config['MOCK_COM'], enable_zmq=not args.disable_zmq, grc_uplink_address=args.grc_uplink_address, grc_downlink_address=args.grc_downlink_address)
 
 print 'Starting devices: {}'.format(', '.join(sorted(devices_to_enable.keys())))
 

--- a/integration_tests/tools/just_mocks.py
+++ b/integration_tests/tools/just_mocks.py
@@ -94,6 +94,11 @@ Arguments may also be stored in file and passed with '@file' syntax. Arguments i
 
     parser.add_argument('-z', '--disable-zmq', action='store_true', default=False, help="Disable ZeroMQ COMM adapter")
 
+    parser.add_argument('--grc_uplink_ip', required=False, default='localhost', help="GRC Uplink IP")
+    parser.add_argument('--grc_uplink_port', required=False, default=7002, help="GRC Uplink PORT")
+    parser.add_argument('--grc_downlink_ip', required=False, default='localhost', help="GRC Downlink IP")
+    parser.add_argument('--grc_downlink_port', required=False, default=7003, help="GRC Downlink PORT")
+
     device_selection_group = parser.add_mutually_exclusive_group(required=True)
     device_selection_group.add_argument('--except',
                                         help="Enable all devices except selected",
@@ -121,7 +126,7 @@ Arguments may also be stored in file and passed with '@file' syntax. Arguments i
 
 
 class JustMocks(object):
-    def __init__(self, mock_com, enable_zmq):
+    def __init__(self, mock_com, enable_zmq, grc_uplink_ip="localhost", grc_uplink_port=7002, grc_downlink_ip="localhost", grc_downlink_port=7003):
         self._mock_com = mock_com
 
         self.i2c = I2CMock(mock_com)
@@ -153,7 +158,7 @@ class JustMocks(object):
         self.i2c.add_pld_device(self.gyro)
 
         if enable_zmq:
-            self.zmq_adapter = ZeroMQAdapter(self.comm)
+            self.zmq_adapter = ZeroMQAdapter(self.comm, grc_uplink_ip=grc_uplink_ip, grc_uplink_port=grc_uplink_port, grc_downlink_ip=grc_downlink_ip, grc_downlink_port=grc_downlink_port)
 
     def start(self, devices_to_enable):
         self.i2c.start(enable_devices=False)
@@ -190,7 +195,8 @@ config = imp.load_source('config', args.config)
 
 devices_to_enable = {k: AVAILABLE_DEVICES[k] for k in args.enabled_devices}
 
-just_mocks = JustMocks(mock_com=config.config['MOCK_COM'], enable_zmq=not args.disable_zmq)
+just_mocks = JustMocks(mock_com=config.config['MOCK_COM'], enable_zmq=not args.disable_zmq,
+					  grc_uplink_ip=args.grc_uplink_ip, grc_uplink_port=args.grc_uplink_port, grc_downlink_ip=args.grc_downlink_ip, grc_downlink_port=args.grc_downlink_port)
 
 print 'Starting devices: {}'.format(', '.join(sorted(devices_to_enable.keys())))
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pw-sat2/pwsat2obc/400)
<!-- Reviewable:end -->
